### PR TITLE
Decouple target functions from model base

### DIFF
--- a/src/models/targets/configs/base.py
+++ b/src/models/targets/configs/base.py
@@ -1,14 +1,18 @@
 from dataclasses import dataclass, field
-from src.models.architectures.configs.base import ModelConfig
+from abc import ABC
+
 import torch
 from dataclasses_json import dataclass_json, config
 
 from src.utils.serialization_utils import encode_shape, decode_shape
 
+
 @dataclass_json
 @dataclass(kw_only=True)
-class TargetFunctionConfig(ModelConfig):
+class TargetFunctionConfig(ABC):
     """Base configuration for target functions."""
+
+    model_type: str = field(init=False)
     input_shape: torch.Size = field(
         metadata=config(encoder=encode_shape, decoder=decode_shape)
     )

--- a/src/models/targets/target_function.py
+++ b/src/models/targets/target_function.py
@@ -1,19 +1,38 @@
-import torch
-from abc import abstractmethod
+from __future__ import annotations
 
-from src.models.architectures.model import Model
+import torch
+import torch.nn as nn
+from abc import ABC, abstractmethod
+
 from .configs.base import TargetFunctionConfig
 
 
-class TargetFunction(Model):
+class TargetFunction(nn.Module, ABC):
     def __init__(self, config: TargetFunctionConfig):
-        super().__init__(config)
+        super().__init__()
+        self.config = config
         self.input_shape = config.input_shape
         self.output_shape = config.output_shape
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         self._validate_input(x)
         return self._forward(x)
+
+    def initialize_weights(self) -> None:  # pragma: no cover - default no-op
+        """Initialize model parameters.
+
+        Subclasses may override this to set up their parameters.
+        """
+        pass
+
+    def get_base_model(self) -> "TargetFunction | None":  # pragma: no cover - default no-op
+        """Return a base-width reference model if available.
+
+        Target functions that do not implement MuP-style width scaling simply
+        return ``None``.  Subclasses may override this to provide a concrete
+        model used for shape initialisation.
+        """
+        return None
 
     @abstractmethod
     def _forward(self, x: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
## Summary
- refactor `TargetFunction` to derive directly from `nn.Module`, storing config and implementing the utility hooks previously inherited from `Model`
- update `TargetFunctionConfig` to define its own shared fields without relying on `ModelConfig`

## Testing
- pytest tests/unit/models/targets -q
- pytest tests/unit/data/joint_distributions/test_mapped_joint_distribution.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d3ef42af6c8320a2c2db58be2b77b9