### PR TITLE
Refactor SumProd target to standalone module

### DIFF
--- a/src/models/targets/configs/sum_prod.py
+++ b/src/models/targets/configs/sum_prod.py
@@ -4,7 +4,6 @@ from typing import List
 import torch
 from dataclasses_json import dataclass_json, config
 
-from .base import TargetFunctionConfig
 from .target_function_config_registry import register_target_function_config
 from src.utils.serialization_utils import encode_shape, decode_shape
 
@@ -12,7 +11,7 @@ from src.utils.serialization_utils import encode_shape, decode_shape
 @register_target_function_config("SumProdTarget")
 @dataclass_json
 @dataclass(kw_only=True)
-class SumProdTargetConfig(TargetFunctionConfig):
+class SumProdTargetConfig:
     """Configuration for :class:`SumProdTarget`.
 
     ``indices_list`` is a list where each element is a list of indices for a
@@ -22,8 +21,14 @@ class SumProdTargetConfig(TargetFunctionConfig):
     applied by :class:`SumProdTarget`.
     """
 
+    model_type: str = field(init=False, default="SumProdTarget")
     input_shape: torch.Size = field(
         metadata=config(encoder=encode_shape, decoder=decode_shape)
+    )
+    output_shape: torch.Size = field(
+        init=False,
+        default_factory=lambda: torch.Size([1]),
+        metadata=config(encoder=encode_shape, decoder=decode_shape),
     )
     indices_list: List[List[int]] = field(default_factory=list)
     weights: List[float] = field(default_factory=list)
@@ -32,6 +37,14 @@ class SumProdTargetConfig(TargetFunctionConfig):
     def __post_init__(self) -> None:
         self.model_type = "SumProdTarget"
         self.output_shape = torch.Size([1])
+        if not isinstance(self.input_shape, torch.Size):
+            raise TypeError(
+                f"input_shape must be torch.Size, got {type(self.input_shape)}"
+            )
+        if not isinstance(self.model_type, str):
+            raise TypeError(
+                f"model_type must be a str, got {type(self.model_type)}"
+            )
         if not self.indices_list:
             raise ValueError("indices_list must be a non-empty list")
         if len(self.weights) != len(self.indices_list):
@@ -42,4 +55,3 @@ class SumProdTargetConfig(TargetFunctionConfig):
                 raise ValueError("each indices group must be non-empty")
             if any(i < 0 or i >= total_dim for i in idx_group):
                 raise ValueError("indices cannot exceed input dimension or be negative")
-        super().__post_init__()

--- a/src/models/targets/sum_prod.py
+++ b/src/models/targets/sum_prod.py
@@ -1,17 +1,22 @@
+from __future__ import annotations
+
 import torch
+import torch.nn as nn
 from torch import Tensor
 
-from src.models.targets.target_function import TargetFunction
 from src.models.targets.target_function_registry import register_target_function
 from src.models.targets.configs.sum_prod import SumProdTargetConfig
 
 
 @register_target_function("SumProdTarget")
-class SumProdTarget(TargetFunction):
+class SumProdTarget(nn.Module):
     """Compute a weighted sum of product terms over selected coordinates."""
 
     def __init__(self, config: SumProdTargetConfig):
-        super().__init__(config)
+        super().__init__()
+        self.config = config
+        self.input_shape = config.input_shape
+        self.output_shape = config.output_shape
         self.indices_list = [list(group) for group in config.indices_list]
         self.weights = [float(weight) for weight in config.weights]
         self.normalize = bool(config.normalize)
@@ -21,6 +26,10 @@ class SumProdTarget(TargetFunction):
         weights_tensor = torch.tensor(self.weights, dtype=torch.float32)
         self.register_buffer("weights_tensor", weights_tensor)
         self.scale = self._compute_normalization() if self.normalize else 1.0
+
+    def forward(self, x: Tensor) -> Tensor:
+        self._validate_input(x)
+        return self._forward(x)
 
     def _forward(self, X: Tensor) -> Tensor:
         flat = X.reshape(*X.shape[:-len(self.input_shape)], -1)
@@ -35,6 +44,13 @@ class SumProdTarget(TargetFunction):
             total = total + weight * flat[..., group].prod(dim=-1)
         total = total * self.scale
         return total.unsqueeze(-1)
+
+    def initialize_weights(self) -> None:  # pragma: no cover - default no-op
+        """Initialize model parameters."""
+
+    def get_base_model(self) -> SumProdTarget | None:  # pragma: no cover - default no-op
+        """Return a base-width reference model if available."""
+        return None
 
     def _compute_normalization(self) -> float:
         num_samples = 2048
@@ -51,6 +67,22 @@ class SumProdTarget(TargetFunction):
             return float(1.0 / torch.sqrt(var))
         else:
             return 1.0
+
+    def _validate_input(self, x: Tensor) -> None:
+        expected_rank = len(self.input_shape)
+
+        if x.ndim <= expected_rank:
+            raise ValueError(
+                "Input must include at least one batch dimension. "
+                f"Expected tensor of rank > {expected_rank} (batch + {self.input_shape}), "
+                f"but got rank {x.ndim}."
+            )
+
+        if x.shape[-expected_rank:] != self.input_shape:
+            raise ValueError(
+                "Input shape mismatch. Expected trailing dimensions "
+                f"{self.input_shape}, but got {tuple(x.shape)}."
+            )
 
     def __str__(self) -> str:
         return (


### PR DESCRIPTION
## Summary
- refactor `SumProdTarget` to inherit directly from `nn.Module` while preserving configuration-driven metadata, input validation, and scaling behaviour
- adjust `SumProdTargetConfig` to operate without `TargetFunctionConfig`, maintaining serialization and validation logic

## Testing
- pytest tests/unit/models/targets/test_sum_prod_target.py tests/unit/models/targets/configs/test_sum_prod_config.py

------
https://chatgpt.com/codex/tasks/task_e_68d3f8c07fb483209dc658101078d6ea