### PR TITLE
Fix loss config indentation in train MLP yaml

### DIFF
--- a/scripts/train_mlp/train_mlp.yaml
+++ b/scripts/train_mlp/train_mlp.yaml
@@ -68,6 +68,7 @@ trainer_config:
             - 1.0
             - 1.0
             - 1.0
+    loss_config:
         name: MSELoss
         eval_type: regression
     train_size: 8192


### PR DESCRIPTION
## Summary
- move the loss configuration out of the joint distribution section in `train_mlp.yaml`
- restore proper `loss_config` block so the trainer receives both loss and distribution settings

## Testing
- not run (YAML-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d51373252883209d397b63a04f937c