### PR TITLE
Wrap train MLP distribution with Gaussian noise

### DIFF
--- a/scripts/train_mlp/train_mlp.yaml
+++ b/scripts/train_mlp/train_mlp.yaml
@@ -32,42 +32,51 @@ trainer_config:
         mup: true
         weight_decay: 0.0
     joint_distribution_config:
-        distribution_type: MappedJointDistribution
-        distribution_config:
-            distribution_type: Hypercube
+        distribution_type: NoisyDistribution
+        base_distribution_config:
+            distribution_type: MappedJointDistribution
+            distribution_config:
+                distribution_type: Hypercube
+                input_shape:
+                - 16
+                dtype: float32
+            target_function_config:
+                model_type: SumProdTarget
+                input_shape:
+                - 16
+                indices_list:
+                - [0]
+                - [0, 1]
+                - [0, 1, 2]
+                - [0, 1, 2, 3]
+                - [0, 1, 2, 3, 4]
+                - [0, 1, 2, 3, 4, 5]
+                - [0, 1, 2, 3, 4, 5, 6]
+                - [0, 1, 2, 3, 4, 5, 6, 7]
+                - [0, 1, 2, 3, 4, 5, 6, 7, 8]
+                - [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+                - [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+                - [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+                weights:
+                - 1.0
+                - 1.0
+                - 1.0
+                - 1.0
+                - 1.0
+                - 1.0
+                - 1.0
+                - 1.0
+                - 1.0
+                - 1.0
+                - 1.0
+                - 1.0
+        noise_distribution_config:
+            distribution_type: Gaussian
             input_shape:
-            - 16
+            - 1
             dtype: float32
-        target_function_config:
-            model_type: SumProdTarget
-            input_shape:
-            - 16
-            indices_list:
-            - [0]
-            - [0, 1]
-            - [0, 1, 2]
-            - [0, 1, 2, 3]
-            - [0, 1, 2, 3, 4]
-            - [0, 1, 2, 3, 4, 5]
-            - [0, 1, 2, 3, 4, 5, 6]
-            - [0, 1, 2, 3, 4, 5, 6, 7]
-            - [0, 1, 2, 3, 4, 5, 6, 7, 8]
-            - [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-            - [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-            - [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
-            weights:
-            - 1.0
-            - 1.0
-            - 1.0
-            - 1.0
-            - 1.0
-            - 1.0
-            - 1.0
-            - 1.0
-            - 1.0
-            - 1.0
-            - 1.0
-            - 1.0
+            mean: 0.0
+            std: 0.1
     loss_config:
         name: MSELoss
         eval_type: regression


### PR DESCRIPTION
## Summary
- wrap the train MLP joint distribution in a NoisyDistribution so the base configuration is unchanged
- add a Gaussian noise distribution with variance 0.01 to perturb the outputs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d51b3e1d9c8320bc7ee8282856a891