### PR TITLE
Simplify NoisyDistribution noise configuration

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -45,7 +45,7 @@ src/
         to build the provider.  Device placement is inherited from ``dist`` and
         the factory resolves the provider class via :data:`DATA_PROVIDER_REGISTRY`.
   - **`MappedJointDistribution`** – pairs a `Distribution` with a `TargetFunction`; `sample(seed)` draws `X` then computes `y = f(X)`.
-- **`NoisyDistribution`** – wraps another `JointDistribution` and adds noise sampled from a separate `Distribution`.
+- **`NoisyDistribution`** – wraps another `JointDistribution` and adds Gaussian noise with configurable mean and standard deviation.
   - **`RepresentorDistribution`** – *loaded lazily*; produces datasets from intermediate model representations using a `ModelRepresentor`.
 
 #### Target Functions

--- a/scripts/mlp_recovery/mlp_recovery.yaml
+++ b/scripts/mlp_recovery/mlp_recovery.yaml
@@ -27,13 +27,8 @@ teacher_trainer_config:
             dtype: float32
             mean: 0.0
             std: 1.0
-        noise_distribution_config:
-            distribution_type: Gaussian
-            input_shape:
-            - 1
-            dtype: float32
-            mean: 0.0
-            std: 1.0
+        noise_mean: 0.0
+        noise_std: 1.0
     loss_config:
         name: MSELoss
         eval_type: regression

--- a/scripts/train_mlp/train_mlp.yaml
+++ b/scripts/train_mlp/train_mlp.yaml
@@ -57,13 +57,8 @@ trainer_config:
                 - 1.0
                 - 1.0
                 - 1.0
-        noise_distribution_config:
-            distribution_type: Gaussian
-            input_shape:
-            - 1
-            dtype: float32
-            mean: 0.0
-            std: 0.1
+        noise_mean: 0.0
+        noise_std: 0.1
     loss_config:
         name: MSELoss
         eval_type: regression

--- a/src/data/joint_distributions/configs/noisy_distribution.py
+++ b/src/data/joint_distributions/configs/noisy_distribution.py
@@ -15,15 +15,13 @@ class NoisyDistributionConfig(JointDistributionConfig):
     base_distribution_config: JointDistributionConfig = field(
         metadata=config(
             encoder=lambda c: c.to_dict(),
-            decoder=lambda d: d if isinstance(d, JointDistributionConfig) else build_joint_distribution_config_from_dict(d),
+            decoder=lambda d: d
+            if isinstance(d, JointDistributionConfig)
+            else build_joint_distribution_config_from_dict(d),
         )
     )
-    noise_distribution_config: JointDistributionConfig = field(
-        metadata=config(
-            encoder=lambda c: c.to_dict(),
-            decoder=lambda d: d if isinstance(d, JointDistributionConfig) else build_joint_distribution_config_from_dict(d),
-        )
-    )
+    noise_mean: float = 0.0
+    noise_std: float = 1.0
 
     def __post_init__(self) -> None:
         self.input_shape = self.base_distribution_config.input_shape

--- a/src/experiments/experiments/mlp_recovery.py
+++ b/src/experiments/experiments/mlp_recovery.py
@@ -18,7 +18,6 @@ from src.data.joint_distributions.configs.representor_distribution import (
 from src.data.joint_distributions.configs.noisy_distribution import (
     NoisyDistributionConfig,
 )
-from src.data.joint_distributions.configs.gaussian import GaussianConfig
 
 @register_experiment("MLPRecovery")
 class MLPRecovery(Experiment):
@@ -66,14 +65,10 @@ class MLPRecovery(Experiment):
         )
 
         if self.config.noise_variance > 0.0:
-            noise_cfg = GaussianConfig(
-                input_shape=representor_cfg.output_shape,
-                mean=0.0,
-                std=math.sqrt(self.config.noise_variance),
-            )
             trainer_cfg.joint_distribution_config = NoisyDistributionConfig(
                 base_distribution_config=representor_cfg,
-                noise_distribution_config=noise_cfg,
+                noise_mean=0.0,
+                noise_std=math.sqrt(self.config.noise_variance),
             )
         else:
             trainer_cfg.joint_distribution_config = representor_cfg

--- a/tests/unit/data/iterators/test_noisy_iterator.py
+++ b/tests/unit/data/iterators/test_noisy_iterator.py
@@ -7,7 +7,6 @@ from src.data.providers.noisy_provider import NoisyProvider
 from src.data.providers import create_data_provider_from_distribution
 from tests.unit.data.conftest import (
     DummyJointDistribution,
-    AddOneNoiseDistributionConfig,
     dummy_distribution,
 )
 
@@ -15,7 +14,8 @@ from tests.unit.data.conftest import (
 def _make_distribution():
     cfg = NoisyDistributionConfig(
         base_distribution_config=DummyJointDistribution._Config(),
-        noise_distribution_config=AddOneNoiseDistributionConfig(),
+        noise_mean=1.0,
+        noise_std=0.0,
     )
     return create_joint_distribution(cfg, torch.device("cpu"))
 

--- a/tests/unit/data/joint_distributions/configs/test_noisy_distribution_config.py
+++ b/tests/unit/data/joint_distributions/configs/test_noisy_distribution_config.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 from src.data.joint_distributions.configs.noisy_distribution import NoisyDistributionConfig
 from src.data.joint_distributions.configs.joint_distribution_config_registry import (
@@ -8,10 +9,7 @@ from src.data.joint_distributions.configs.joint_distribution_config_registry imp
 from src.data.joint_distributions.configs.mapped_joint_distribution import MappedJointDistributionConfig
 from src.data.joint_distributions.configs.gaussian import GaussianConfig
 from src.models.targets.configs.sum_prod import SumProdTargetConfig
-from tests.unit.data.conftest import (
-    DummyJointDistribution,
-    add_one_noise_dist_cfg,
-)
+from tests.unit.data.conftest import DummyJointDistribution
 
 
 def test_noisy_config_registered():
@@ -22,20 +20,23 @@ def test_noisy_config_registered():
     )
 
 
-def test_build_noisy_config(dummy_distribution, add_one_noise_dist_cfg):
+def test_build_noisy_config(dummy_distribution):
     cfg = build_joint_distribution_config(
         "NoisyDistribution",
         base_distribution_config=DummyJointDistribution._Config(),
-        noise_distribution_config=add_one_noise_dist_cfg,
+        noise_mean=1.0,
+        noise_std=0.5,
     )
     assert isinstance(cfg, NoisyDistributionConfig)
     assert cfg.distribution_type == "NoisyDistribution"
     dummy_cfg = DummyJointDistribution._Config()
     assert cfg.input_shape == dummy_cfg.input_shape
     assert cfg.output_shape == dummy_cfg.output_shape
+    assert cfg.noise_mean == pytest.approx(1.0)
+    assert cfg.noise_std == pytest.approx(0.5)
 
 
-def test_noisy_config_json_roundtrip(add_one_noise_dist_cfg):
+def test_noisy_config_json_roundtrip():
     base_cfg = MappedJointDistributionConfig(
         distribution_config=GaussianConfig(
             input_shape=torch.Size([2]), mean=0.0, std=1.0
@@ -49,14 +50,15 @@ def test_noisy_config_json_roundtrip(add_one_noise_dist_cfg):
     )
     cfg = NoisyDistributionConfig(
         base_distribution_config=base_cfg,
-        noise_distribution_config=add_one_noise_dist_cfg,
+        noise_mean=0.0,
+        noise_std=1.0,
     )
     json_str = cfg.to_json()
     restored = NoisyDistributionConfig.from_json(json_str)
     assert restored == cfg
 
 
-def test_noisy_config_from_dict_via_registry(add_one_noise_dist_cfg):
+def test_noisy_config_from_dict_via_registry():
     data = {
         "distribution_type": "NoisyDistribution",
         "base_distribution_config": {
@@ -76,13 +78,12 @@ def test_noisy_config_from_dict_via_registry(add_one_noise_dist_cfg):
                 "normalize": False,
             },
         },
-        "noise_distribution_config": {
-            "distribution_type": "AddOneNoiseDistribution",
-            "input_shape": [1],
-            "dtype": "float32",
-        },
+        "noise_mean": 0.25,
+        "noise_std": 0.75,
     }
     cfg = build_joint_distribution_config_from_dict(data)
     assert isinstance(cfg, NoisyDistributionConfig)
     assert cfg.input_shape == torch.Size([2])
     assert cfg.output_shape == torch.Size([1])
+    assert cfg.noise_mean == pytest.approx(0.25)
+    assert cfg.noise_std == pytest.approx(0.75)

--- a/tests/unit/data/joint_distributions/test_average_output_variance.py
+++ b/tests/unit/data/joint_distributions/test_average_output_variance.py
@@ -10,10 +10,7 @@ from src.data.joint_distributions.configs.noisy_distribution import (
     NoisyDistributionConfig,
 )
 from src.models.targets.configs.sum_prod import SumProdTargetConfig
-from tests.unit.data.conftest import (
-    DummyJointDistribution,
-    AddOneNoiseDistributionConfig,
-)
+from tests.unit.data.conftest import DummyJointDistribution
 
 
 def test_gaussian_variance_zero():
@@ -43,7 +40,8 @@ def test_mapped_linear_variance_matches_dimension():
 def test_noisy_distribution_variance_zero():
     noisy_cfg = NoisyDistributionConfig(
         base_distribution_config=DummyJointDistribution._Config(),
-        noise_distribution_config=AddOneNoiseDistributionConfig(),
+        noise_mean=1.0,
+        noise_std=0.0,
     )
     dist = create_joint_distribution(noisy_cfg, torch.device("cpu"))
     var = dist.average_output_variance(n_samples=1000, seed=0)

--- a/tests/unit/data/joint_distributions/test_forward_consistency.py
+++ b/tests/unit/data/joint_distributions/test_forward_consistency.py
@@ -11,10 +11,7 @@ from src.data.joint_distributions.configs.representor_distribution import (
 )
 
 from tests.helpers.stubs import StubJointDistribution
-from tests.unit.data.conftest import (
-    DummyJointDistribution,
-    AddOneNoiseDistributionConfig,
-)
+from tests.unit.data.conftest import DummyJointDistribution
 from src.models.targets.configs.sum_prod import SumProdTargetConfig
 
 

--- a/tests/unit/data/joint_distributions/test_noisy_distribution_basic.py
+++ b/tests/unit/data/joint_distributions/test_noisy_distribution_basic.py
@@ -1,13 +1,14 @@
 import torch
 from src.data.joint_distributions import create_joint_distribution
 from src.data.joint_distributions.configs.noisy_distribution import NoisyDistributionConfig
-from tests.unit.data.conftest import DummyJointDistribution, AddOneNoiseDistributionConfig
+from tests.unit.data.conftest import DummyJointDistribution
 
 
 def test_noisy_distribution_construct_and_sample():
     cfg = NoisyDistributionConfig(
         base_distribution_config=DummyJointDistribution._Config(),
-        noise_distribution_config=AddOneNoiseDistributionConfig(),
+        noise_mean=1.0,
+        noise_std=0.0,
     )
     dist = create_joint_distribution(cfg, torch.device("cpu"))
 

--- a/tests/unit/experiments/test_mlp_recovery.py
+++ b/tests/unit/experiments/test_mlp_recovery.py
@@ -17,7 +17,6 @@ from src.data.joint_distributions.configs.representor_distribution import (
 from src.data.joint_distributions.configs.noisy_distribution import (
     NoisyDistributionConfig,
 )
-from src.data.joint_distributions.configs.gaussian import GaussianConfig
 
 
 def test_mlp_recovery_runs(tmp_path, monkeypatch):
@@ -320,5 +319,6 @@ def test_student_distribution_with_noise(tmp_path):
     jd_cfg = student_trainer.joint_distribution_config
     assert isinstance(jd_cfg, NoisyDistributionConfig)
     assert isinstance(jd_cfg.base_distribution_config, RepresentorDistributionConfig)
-    assert isinstance(jd_cfg.noise_distribution_config, GaussianConfig)
+    assert jd_cfg.noise_mean == pytest.approx(0.0)
+    assert jd_cfg.noise_std == pytest.approx(0.2)
 


### PR DESCRIPTION
## Summary
- simplify `NoisyDistributionConfig` to accept Gaussian noise parameters directly
- have `NoisyDistribution` build its own Gaussian noise distribution using the configured mean and standard deviation
- update experiments, configs, docs, YAMLs, and tests to reflect the streamlined configuration

## Testing
- pytest tests/unit/data/joint_distributions tests/unit/data/iterators/test_noisy_iterator.py tests/unit/experiments/test_mlp_recovery.py

------
https://chatgpt.com/codex/tasks/task_e_68d520ea31108320bbcbe0528120ee50