### PR TITLE
Fix SeededNoisyDataset noise shape handling

### DIFF
--- a/src/data/providers/seeded_noisy_dataset.py
+++ b/src/data/providers/seeded_noisy_dataset.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+
 import torch
 from torch.utils.data import Dataset
 
@@ -22,6 +24,13 @@ class SeededNoisyDataset(Dataset):
         self.size = size
         self.seed = seed
 
+        # Cache shape metadata provided directly by ``NoisyDistribution`` so
+        # that ``__getitem__`` does not need to recompute it for every sample.
+        self._base_size = distribution.base_input_size
+        self._base_shape = distribution.base_input_shape
+        self._noise_shape = tuple(distribution.noise_shape)
+        self._noise_size = math.prod(self._noise_shape)
+
     def __len__(self) -> int:  # type: ignore[override]
         return self.size
 
@@ -38,15 +47,11 @@ class SeededNoisyDataset(Dataset):
         X_with_noise = X_with_noise.squeeze(0)
         y_base = y_base.squeeze(0)
 
-        base_size = self.distribution.base_input_size
-        base_shape = self.distribution.base_input_shape
-        noise_shape = self.distribution.noise_distribution.input_shape
+        X_base_flat = X_with_noise[: self._base_size]
+        X_noise_flat = X_with_noise[self._base_size : self._base_size + self._noise_size]
 
-        X_base_flat = X_with_noise[:base_size]
-        X_noise_flat = X_with_noise[base_size:]
-
-        X_base = X_base_flat.reshape(*base_shape)
-        X_noise = X_noise_flat.reshape(*noise_shape)
+        X_base = X_base_flat.reshape(*self._base_shape)
+        X_noise = X_noise_flat.reshape(*self._noise_shape)
 
         # Return the noise sample so that the provider can add it to ``y_base``.
         return X_base, y_base, X_noise


### PR DESCRIPTION
## Summary
- cache the base and noise shapes directly from `NoisyDistribution`
- reshape noise batches using the distribution's `noise_shape` attributes instead of a nonexistent proxy

## Testing
- pytest tests/unit/data/iterators/test_noisy_iterator.py

------
https://chatgpt.com/codex/tasks/task_e_68d526f2dfa48320ac057adb003fb630