### PR TITLE
Refactor NoisyDistribution to own target mapping

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -45,7 +45,7 @@ src/
         to build the provider.  Device placement is inherited from ``dist`` and
         the factory resolves the provider class via :data:`DATA_PROVIDER_REGISTRY`.
   - **`MappedJointDistribution`** – pairs a `Distribution` with a `TargetFunction`; `sample(seed)` draws `X` then computes `y = f(X)`.
-- **`NoisyDistribution`** – wraps another `JointDistribution` and adds Gaussian noise with configurable mean and standard deviation.
+- **`NoisyDistribution`** – mirrors a `MappedJointDistribution` built from a base distribution and target function, then adds Gaussian noise with configurable mean and standard deviation to its targets.
   - **`RepresentorDistribution`** – *loaded lazily*; produces datasets from intermediate model representations using a `ModelRepresentor`.
 
 #### Target Functions

--- a/scripts/mlp_recovery/mlp_recovery.yaml
+++ b/scripts/mlp_recovery/mlp_recovery.yaml
@@ -27,6 +27,15 @@ teacher_trainer_config:
             dtype: float32
             mean: 0.0
             std: 1.0
+        target_function_config:
+            model_type: SumProdTarget
+            input_shape:
+            - 8
+            indices_list:
+            - [0]
+            weights:
+            - 0.0
+            normalize: false
         noise_mean: 0.0
         noise_std: 1.0
     loss_config:

--- a/scripts/train_mlp/train_mlp.yaml
+++ b/scripts/train_mlp/train_mlp.yaml
@@ -21,42 +21,40 @@ trainer_config:
     joint_distribution_config:
         distribution_type: NoisyDistribution
         base_distribution_config:
-            distribution_type: MappedJointDistribution
-            distribution_config:
-                distribution_type: Hypercube
-                input_shape:
-                - 16
-                dtype: float32
-            target_function_config:
-                model_type: SumProdTarget
-                input_shape:
-                - 16
-                indices_list:
-                - [0]
-                - [0, 1]
-                - [0, 1, 2]
-                - [0, 1, 2, 3]
-                - [0, 1, 2, 3, 4]
-                - [0, 1, 2, 3, 4, 5]
-                - [0, 1, 2, 3, 4, 5, 6]
-                - [0, 1, 2, 3, 4, 5, 6, 7]
-                - [0, 1, 2, 3, 4, 5, 6, 7, 8]
-                - [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-                - [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-                - [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
-                weights:
-                - 1.0
-                - 1.0
-                - 1.0
-                - 1.0
-                - 1.0
-                - 1.0
-                - 1.0
-                - 1.0
-                - 1.0
-                - 1.0
-                - 1.0
-                - 1.0
+            distribution_type: Hypercube
+            input_shape:
+            - 16
+            dtype: float32
+        target_function_config:
+            model_type: SumProdTarget
+            input_shape:
+            - 16
+            indices_list:
+            - [0]
+            - [0, 1]
+            - [0, 1, 2]
+            - [0, 1, 2, 3]
+            - [0, 1, 2, 3, 4]
+            - [0, 1, 2, 3, 4, 5]
+            - [0, 1, 2, 3, 4, 5, 6]
+            - [0, 1, 2, 3, 4, 5, 6, 7]
+            - [0, 1, 2, 3, 4, 5, 6, 7, 8]
+            - [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+            - [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+            - [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+            weights:
+            - 1.0
+            - 1.0
+            - 1.0
+            - 1.0
+            - 1.0
+            - 1.0
+            - 1.0
+            - 1.0
+            - 1.0
+            - 1.0
+            - 1.0
+            - 1.0
         noise_mean: 0.0
         noise_std: 0.1
     loss_config:

--- a/src/data/joint_distributions/configs/noisy_distribution.py
+++ b/src/data/joint_distributions/configs/noisy_distribution.py
@@ -6,6 +6,7 @@ from .joint_distribution_config_registry import (
     register_joint_distribution_config,
     build_joint_distribution_config_from_dict,
 )
+from src.models.targets.configs.sum_prod import SumProdTargetConfig
 
 
 @register_joint_distribution_config("NoisyDistribution")
@@ -20,11 +21,19 @@ class NoisyDistributionConfig(JointDistributionConfig):
             else build_joint_distribution_config_from_dict(d),
         )
     )
+    target_function_config: SumProdTargetConfig = field(
+        metadata=config(
+            encoder=lambda c: c.to_dict(),
+            decoder=lambda d: d
+            if isinstance(d, SumProdTargetConfig)
+            else SumProdTargetConfig.from_dict(d),
+        )
+    )
     noise_mean: float = 0.0
     noise_std: float = 1.0
 
     def __post_init__(self) -> None:
         self.input_shape = self.base_distribution_config.input_shape
-        self.output_shape = self.base_distribution_config.output_shape
+        self.output_shape = self.target_function_config.output_shape
         self.distribution_type = "NoisyDistribution"
 

--- a/src/data/providers/noisy_provider.py
+++ b/src/data/providers/noisy_provider.py
@@ -47,6 +47,7 @@ class NoisyProvider(DataProvider):
     def __iter__(self) -> Iterator[Tuple[torch.Tensor, torch.Tensor]]:
         for batch in self.data_loader:
             X_base = batch[0]
+            y_base = batch[1]
             y_noise = batch[2]
-            X_final, y_base = self.joint_distribution.base_joint_distribution.forward(X_base)
+            X_final = self.joint_distribution.base_joint_distribution.forward_X(X_base)
             yield X_final, y_base + y_noise

--- a/src/experiments/experiments/mlp_recovery.py
+++ b/src/experiments/experiments/mlp_recovery.py
@@ -65,8 +65,16 @@ class MLPRecovery(Experiment):
         )
 
         if self.config.noise_variance > 0.0:
+            student_base_cfg = trainer_cfg.joint_distribution_config
+            if student_base_cfg is None or not hasattr(
+                student_base_cfg, "target_function_config"
+            ):
+                raise ValueError(
+                    "Student trainer must define a target_function_config when using a NoisyDistribution"
+                )
             trainer_cfg.joint_distribution_config = NoisyDistributionConfig(
                 base_distribution_config=representor_cfg,
+                target_function_config=student_base_cfg.target_function_config,
                 noise_mean=0.0,
                 noise_std=math.sqrt(self.config.noise_variance),
             )

--- a/tests/unit/data/conftest.py
+++ b/tests/unit/data/conftest.py
@@ -226,6 +226,12 @@ def trained_noisy_trainer(tmp_path, adam_config) -> Trainer:
         optimizer_config=adam_config,
         joint_distribution_config=NoisyDistributionConfig(
             base_distribution_config=DummyJointDistribution._Config(),
+            target_function_config=SumProdTargetConfig(
+                input_shape=torch.Size([2]),
+                indices_list=[[0]],
+                weights=[0.0],
+                normalize=False,
+            ),
             noise_mean=1.0,
             noise_std=0.0,
         ),

--- a/tests/unit/data/iterators/test_noisy_iterator.py
+++ b/tests/unit/data/iterators/test_noisy_iterator.py
@@ -5,6 +5,7 @@ from src.data.joint_distributions import create_joint_distribution
 from src.data.joint_distributions.configs.noisy_distribution import NoisyDistributionConfig
 from src.data.providers.noisy_provider import NoisyProvider
 from src.data.providers import create_data_provider_from_distribution
+from src.models.targets.configs.sum_prod import SumProdTargetConfig
 from tests.unit.data.conftest import (
     DummyJointDistribution,
     dummy_distribution,
@@ -14,6 +15,12 @@ from tests.unit.data.conftest import (
 def _make_distribution():
     cfg = NoisyDistributionConfig(
         base_distribution_config=DummyJointDistribution._Config(),
+        target_function_config=SumProdTargetConfig(
+            input_shape=torch.Size([2]),
+            indices_list=[[0]],
+            weights=[0.0],
+            normalize=False,
+        ),
         noise_mean=1.0,
         noise_std=0.0,
     )
@@ -30,7 +37,7 @@ def test_noisy_iterator_batches_apply_noise(tmp_path):
     for X, y in batches:
         assert X.shape == (2, *dist.input_shape)
         assert y.shape == (2, *dist.output_shape)
-        assert torch.allclose(y, torch.full((2, 1), 6.0))
+        assert torch.allclose(y, torch.full((2, 1), 1.0))
 
 
 def test_noisy_iterator_deterministic(tmp_path):

--- a/tests/unit/data/joint_distributions/configs/test_noisy_distribution_config.py
+++ b/tests/unit/data/joint_distributions/configs/test_noisy_distribution_config.py
@@ -21,17 +21,25 @@ def test_noisy_config_registered():
 
 
 def test_build_noisy_config(dummy_distribution):
+    target_cfg = SumProdTargetConfig(
+        input_shape=torch.Size([2]),
+        indices_list=[[0]],
+        weights=[0.0],
+        normalize=False,
+    )
     cfg = build_joint_distribution_config(
         "NoisyDistribution",
         base_distribution_config=DummyJointDistribution._Config(),
+        target_function_config=target_cfg,
         noise_mean=1.0,
         noise_std=0.5,
     )
     assert isinstance(cfg, NoisyDistributionConfig)
     assert cfg.distribution_type == "NoisyDistribution"
+    assert cfg.target_function_config == target_cfg
     dummy_cfg = DummyJointDistribution._Config()
     assert cfg.input_shape == dummy_cfg.input_shape
-    assert cfg.output_shape == dummy_cfg.output_shape
+    assert cfg.output_shape == target_cfg.output_shape
     assert cfg.noise_mean == pytest.approx(1.0)
     assert cfg.noise_std == pytest.approx(0.5)
 
@@ -50,6 +58,12 @@ def test_noisy_config_json_roundtrip():
     )
     cfg = NoisyDistributionConfig(
         base_distribution_config=base_cfg,
+        target_function_config=SumProdTargetConfig(
+            input_shape=torch.Size([2]),
+            indices_list=[[0]],
+            weights=[1.0],
+            normalize=False,
+        ),
         noise_mean=0.0,
         noise_std=1.0,
     )
@@ -77,6 +91,13 @@ def test_noisy_config_from_dict_via_registry():
                 "weights": [1.0, 1.0],
                 "normalize": False,
             },
+        },
+        "target_function_config": {
+            "model_type": "SumProdTarget",
+            "input_shape": [2],
+            "indices_list": [[0]],
+            "weights": [1.0],
+            "normalize": False,
         },
         "noise_mean": 0.25,
         "noise_std": 0.75,

--- a/tests/unit/data/joint_distributions/test_average_output_variance.py
+++ b/tests/unit/data/joint_distributions/test_average_output_variance.py
@@ -40,6 +40,12 @@ def test_mapped_linear_variance_matches_dimension():
 def test_noisy_distribution_variance_zero():
     noisy_cfg = NoisyDistributionConfig(
         base_distribution_config=DummyJointDistribution._Config(),
+        target_function_config=SumProdTargetConfig(
+            input_shape=torch.Size([2]),
+            indices_list=[[0]],
+            weights=[0.0],
+            normalize=False,
+        ),
         noise_mean=1.0,
         noise_std=0.0,
     )

--- a/tests/unit/data/joint_distributions/test_noisy_distribution_basic.py
+++ b/tests/unit/data/joint_distributions/test_noisy_distribution_basic.py
@@ -1,12 +1,19 @@
 import torch
 from src.data.joint_distributions import create_joint_distribution
 from src.data.joint_distributions.configs.noisy_distribution import NoisyDistributionConfig
+from src.models.targets.configs.sum_prod import SumProdTargetConfig
 from tests.unit.data.conftest import DummyJointDistribution
 
 
 def test_noisy_distribution_construct_and_sample():
     cfg = NoisyDistributionConfig(
         base_distribution_config=DummyJointDistribution._Config(),
+        target_function_config=SumProdTargetConfig(
+            input_shape=torch.Size([2]),
+            indices_list=[[0]],
+            weights=[1.0],
+            normalize=False,
+        ),
         noise_mean=1.0,
         noise_std=0.0,
     )


### PR DESCRIPTION
## Summary
- extend `NoisyDistributionConfig` to accept a target function config and update NoisyDistribution to build its own target function instead of delegating to mapped distributions
- adjust NoisyProvider and related fixtures/tests to use the embedded target outputs and provide explicit SumProd target configs
- update experiment YAML, trainer logic, and documentation to reflect the new configuration pattern

## Testing
- `pytest tests/unit/data/joint_distributions -k noisy`
- `pytest tests/unit/data/iterators/test_noisy_iterator.py`
- `pytest tests/unit/experiments/test_mlp_recovery.py`


------
https://chatgpt.com/codex/tasks/task_e_68d5569d6e6c83209621909f9764ec8c