### PR TITLE
Import SumProdTargetConfig in conftest

### DIFF
--- a/tests/unit/data/conftest.py
+++ b/tests/unit/data/conftest.py
@@ -19,6 +19,7 @@ from src.training.loss.configs.loss import LossConfig
 from tests.helpers.stubs import StubJointDistribution
 import src.data.providers.noisy_provider  # Register NoisyIterator
 from src.data.joint_distributions.configs.noisy_distribution import NoisyDistributionConfig
+from src.models.targets.configs.sum_prod import SumProdTargetConfig
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- import `SumProdTargetConfig` in the tests data conftest to fix the fixture setup

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d55e62b0fc8320ae0952321799c0ba