### PR TITLE
Refactor noisy distribution config to derive base and target

### DIFF
--- a/scripts/train_mlp/train_mlp.yaml
+++ b/scripts/train_mlp/train_mlp.yaml
@@ -20,41 +20,34 @@ trainer_config:
         weight_decay: 0.0
     joint_distribution_config:
         distribution_type: NoisyDistribution
-        base_distribution_config:
-            distribution_type: Hypercube
-            input_shape:
-            - 16
-            dtype: float32
-        target_function_config:
-            model_type: SumProdTarget
-            input_shape:
-            - 16
-            indices_list:
-            - [0]
-            - [0, 1]
-            - [0, 1, 2]
-            - [0, 1, 2, 3]
-            - [0, 1, 2, 3, 4]
-            - [0, 1, 2, 3, 4, 5]
-            - [0, 1, 2, 3, 4, 5, 6]
-            - [0, 1, 2, 3, 4, 5, 6, 7]
-            - [0, 1, 2, 3, 4, 5, 6, 7, 8]
-            - [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-            - [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-            - [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
-            weights:
-            - 1.0
-            - 1.0
-            - 1.0
-            - 1.0
-            - 1.0
-            - 1.0
-            - 1.0
-            - 1.0
-            - 1.0
-            - 1.0
-            - 1.0
-            - 1.0
+        input_dim: 16
+        indices_list:
+        - [0]
+        - [0, 1]
+        - [0, 1, 2]
+        - [0, 1, 2, 3]
+        - [0, 1, 2, 3, 4]
+        - [0, 1, 2, 3, 4, 5]
+        - [0, 1, 2, 3, 4, 5, 6]
+        - [0, 1, 2, 3, 4, 5, 6, 7]
+        - [0, 1, 2, 3, 4, 5, 6, 7, 8]
+        - [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        - [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        - [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+        weights:
+        - 1.0
+        - 1.0
+        - 1.0
+        - 1.0
+        - 1.0
+        - 1.0
+        - 1.0
+        - 1.0
+        - 1.0
+        - 1.0
+        - 1.0
+        - 1.0
+        normalize: false
         noise_mean: 0.0
         noise_std: 0.1
     loss_config:

--- a/src/data/joint_distributions/configs/noisy_distribution.py
+++ b/src/data/joint_distributions/configs/noisy_distribution.py
@@ -1,7 +1,11 @@
 from dataclasses import dataclass, field
+from typing import List
+
+import torch
 from dataclasses_json import dataclass_json, config
 
 from .base import JointDistributionConfig
+from .hypercube import HypercubeConfig
 from .joint_distribution_config_registry import (
     register_joint_distribution_config,
     build_joint_distribution_config_from_dict,
@@ -13,26 +17,61 @@ from src.models.targets.configs.sum_prod import SumProdTargetConfig
 @dataclass_json
 @dataclass(kw_only=True)
 class NoisyDistributionConfig(JointDistributionConfig):
+    input_dim: int
+    indices_list: List[List[int]] = field(default_factory=list)
+    weights: List[float] = field(default_factory=list)
+    normalize: bool = False
+    noise_mean: float = 0.0
+    noise_std: float = 1.0
     base_distribution_config: JointDistributionConfig = field(
+        init=False,
         metadata=config(
             encoder=lambda c: c.to_dict(),
             decoder=lambda d: d
             if isinstance(d, JointDistributionConfig)
             else build_joint_distribution_config_from_dict(d),
-        )
+        ),
     )
     target_function_config: SumProdTargetConfig = field(
+        init=False,
         metadata=config(
             encoder=lambda c: c.to_dict(),
             decoder=lambda d: d
             if isinstance(d, SumProdTargetConfig)
             else SumProdTargetConfig.from_dict(d),
-        )
+        ),
     )
-    noise_mean: float = 0.0
-    noise_std: float = 1.0
 
     def __post_init__(self) -> None:
+        if self.input_dim <= 0:
+            raise ValueError("input_dim must be a positive integer")
+
+        if not self.indices_list:
+            raise ValueError("indices_list must be a non-empty list")
+
+        if len(self.weights) != len(self.indices_list):
+            raise ValueError("weights must have the same length as indices_list")
+
+        for idx_group in self.indices_list:
+            if not idx_group:
+                raise ValueError("each indices group must be non-empty")
+            for index in idx_group:
+                if index < 0:
+                    raise ValueError("indices cannot be negative")
+                if index >= self.input_dim:
+                    raise ValueError(
+                        "indices_list contains an index that is >= input_dim"
+                    )
+
+        input_shape = torch.Size([self.input_dim])
+        self.base_distribution_config = HypercubeConfig(input_shape=input_shape)
+        self.target_function_config = SumProdTargetConfig(
+            input_shape=input_shape,
+            indices_list=self.indices_list,
+            weights=self.weights,
+            normalize=self.normalize,
+        )
+
         self.input_shape = self.base_distribution_config.input_shape
         self.output_shape = self.target_function_config.output_shape
         self.distribution_type = "NoisyDistribution"

--- a/tests/unit/data/conftest.py
+++ b/tests/unit/data/conftest.py
@@ -19,7 +19,6 @@ from src.training.loss.configs.loss import LossConfig
 from tests.helpers.stubs import StubJointDistribution
 import src.data.providers.noisy_provider  # Register NoisyIterator
 from src.data.joint_distributions.configs.noisy_distribution import NoisyDistributionConfig
-from src.models.targets.configs.sum_prod import SumProdTargetConfig
 
 
 @pytest.fixture
@@ -226,13 +225,10 @@ def trained_noisy_trainer(tmp_path, adam_config) -> Trainer:
         model_config=model_cfg,
         optimizer_config=adam_config,
         joint_distribution_config=NoisyDistributionConfig(
-            base_distribution_config=DummyJointDistribution._Config(),
-            target_function_config=SumProdTargetConfig(
-                input_shape=torch.Size([2]),
-                indices_list=[[0]],
-                weights=[0.0],
-                normalize=False,
-            ),
+            input_dim=2,
+            indices_list=[[0]],
+            weights=[0.0],
+            normalize=False,
             noise_mean=1.0,
             noise_std=0.0,
         ),

--- a/tests/unit/data/iterators/test_noisy_iterator.py
+++ b/tests/unit/data/iterators/test_noisy_iterator.py
@@ -1,26 +1,19 @@
-import torch
 import pytest
+import torch
 
 from src.data.joint_distributions import create_joint_distribution
 from src.data.joint_distributions.configs.noisy_distribution import NoisyDistributionConfig
 from src.data.providers.noisy_provider import NoisyProvider
 from src.data.providers import create_data_provider_from_distribution
-from src.models.targets.configs.sum_prod import SumProdTargetConfig
-from tests.unit.data.conftest import (
-    DummyJointDistribution,
-    dummy_distribution,
-)
+from tests.unit.data.conftest import dummy_distribution
 
 
 def _make_distribution():
     cfg = NoisyDistributionConfig(
-        base_distribution_config=DummyJointDistribution._Config(),
-        target_function_config=SumProdTargetConfig(
-            input_shape=torch.Size([2]),
-            indices_list=[[0]],
-            weights=[0.0],
-            normalize=False,
-        ),
+        input_dim=2,
+        indices_list=[[0]],
+        weights=[0.0],
+        normalize=False,
         noise_mean=1.0,
         noise_std=0.0,
     )

--- a/tests/unit/data/joint_distributions/test_average_output_variance.py
+++ b/tests/unit/data/joint_distributions/test_average_output_variance.py
@@ -10,7 +10,6 @@ from src.data.joint_distributions.configs.noisy_distribution import (
     NoisyDistributionConfig,
 )
 from src.models.targets.configs.sum_prod import SumProdTargetConfig
-from tests.unit.data.conftest import DummyJointDistribution
 
 
 def test_gaussian_variance_zero():
@@ -39,13 +38,10 @@ def test_mapped_linear_variance_matches_dimension():
 
 def test_noisy_distribution_variance_zero():
     noisy_cfg = NoisyDistributionConfig(
-        base_distribution_config=DummyJointDistribution._Config(),
-        target_function_config=SumProdTargetConfig(
-            input_shape=torch.Size([2]),
-            indices_list=[[0]],
-            weights=[0.0],
-            normalize=False,
-        ),
+        input_dim=2,
+        indices_list=[[0]],
+        weights=[0.0],
+        normalize=False,
         noise_mean=1.0,
         noise_std=0.0,
     )

--- a/tests/unit/data/joint_distributions/test_noisy_distribution_basic.py
+++ b/tests/unit/data/joint_distributions/test_noisy_distribution_basic.py
@@ -1,19 +1,13 @@
 import torch
 from src.data.joint_distributions import create_joint_distribution
 from src.data.joint_distributions.configs.noisy_distribution import NoisyDistributionConfig
-from src.models.targets.configs.sum_prod import SumProdTargetConfig
-from tests.unit.data.conftest import DummyJointDistribution
 
 
 def test_noisy_distribution_construct_and_sample():
     cfg = NoisyDistributionConfig(
-        base_distribution_config=DummyJointDistribution._Config(),
-        target_function_config=SumProdTargetConfig(
-            input_shape=torch.Size([2]),
-            indices_list=[[0]],
-            weights=[1.0],
-            normalize=False,
-        ),
+        input_dim=2,
+        indices_list=[[0]],
+        weights=[1.0],
         noise_mean=1.0,
         noise_std=0.0,
     )


### PR DESCRIPTION
## Summary
- refactor `NoisyDistributionConfig` to accept `input_dim`, `indices_list`, and `weights`, instantiating a Hypercube base and SumProd target internally with validation of indices
- update noisy distribution-related tests, fixtures, and training YAML to align with the streamlined configuration interface

## Testing
- pytest tests/unit/data/joint_distributions/configs/test_noisy_distribution_config.py
- pytest tests/unit/data/joint_distributions/test_noisy_distribution_basic.py tests/unit/data/joint_distributions/test_average_output_variance.py tests/unit/data/iterators/test_noisy_iterator.py
- pytest tests/unit/data/iterators/test_noisy_iterator.py

------
https://chatgpt.com/codex/tasks/task_e_68d565fb11b48320b4b864f6b5f85c30