### PR TITLE
Refactor noisy distribution to construct base internally

### DIFF
--- a/src/data/joint_distributions/configs/noisy_distribution.py
+++ b/src/data/joint_distributions/configs/noisy_distribution.py
@@ -5,11 +5,7 @@ import torch
 from dataclasses_json import dataclass_json, config
 
 from .base import JointDistributionConfig
-from .hypercube import HypercubeConfig
-from .joint_distribution_config_registry import (
-    register_joint_distribution_config,
-    build_joint_distribution_config_from_dict,
-)
+from .joint_distribution_config_registry import register_joint_distribution_config
 from src.models.targets.configs.sum_prod import SumProdTargetConfig
 
 
@@ -23,15 +19,6 @@ class NoisyDistributionConfig(JointDistributionConfig):
     normalize: bool = False
     noise_mean: float = 0.0
     noise_std: float = 1.0
-    base_distribution_config: JointDistributionConfig = field(
-        init=False,
-        metadata=config(
-            encoder=lambda c: c.to_dict(),
-            decoder=lambda d: d
-            if isinstance(d, JointDistributionConfig)
-            else build_joint_distribution_config_from_dict(d),
-        ),
-    )
     target_function_config: SumProdTargetConfig = field(
         init=False,
         metadata=config(
@@ -64,7 +51,6 @@ class NoisyDistributionConfig(JointDistributionConfig):
                     )
 
         input_shape = torch.Size([self.input_dim])
-        self.base_distribution_config = HypercubeConfig(input_shape=input_shape)
         self.target_function_config = SumProdTargetConfig(
             input_shape=input_shape,
             indices_list=self.indices_list,
@@ -72,7 +58,7 @@ class NoisyDistributionConfig(JointDistributionConfig):
             normalize=self.normalize,
         )
 
-        self.input_shape = self.base_distribution_config.input_shape
+        self.input_shape = input_shape
         self.output_shape = self.target_function_config.output_shape
         self.distribution_type = "NoisyDistribution"
 

--- a/src/data/joint_distributions/noisy_distribution.py
+++ b/src/data/joint_distributions/noisy_distribution.py
@@ -6,16 +6,15 @@ import random
 from .joint_distribution import JointDistribution
 from .configs.noisy_distribution import NoisyDistributionConfig
 from .joint_distribution_registry import register_joint_distribution
+from .hypercube import Hypercube
+from .configs.hypercube import HypercubeConfig
 from src.models.targets.sum_prod import SumProdTarget
 
 @register_joint_distribution("NoisyDistribution")
 class NoisyDistribution(JointDistribution):
     def __init__(self, config: NoisyDistributionConfig, device: torch.device) -> None:
-        from .joint_distribution_factory import create_joint_distribution
-
-        self.base_joint_distribution = create_joint_distribution(
-            config.base_distribution_config, device
-        )
+        hypercube_config = HypercubeConfig(input_shape=config.input_shape)
+        self.base_joint_distribution = Hypercube(hypercube_config, device)
         self.target_function = SumProdTarget(config.target_function_config).to(device)
 
         super().__init__(config=config, device=device)

--- a/tests/unit/data/joint_distributions/configs/test_noisy_distribution_config.py
+++ b/tests/unit/data/joint_distributions/configs/test_noisy_distribution_config.py
@@ -33,7 +33,6 @@ def test_build_noisy_config():
     assert cfg.output_shape == torch.Size([1])
     assert cfg.noise_mean == pytest.approx(1.0)
     assert cfg.noise_std == pytest.approx(0.5)
-    assert cfg.base_distribution_config.distribution_type == "Hypercube"
     assert cfg.target_function_config.indices_list == [[0]]
 
 


### PR DESCRIPTION
## Summary
- simplify `NoisyDistributionConfig` so it only records the input dimension and directly builds the target configuration
- instantiate the hypercube base distribution directly inside `NoisyDistribution`
- update configuration tests to reflect the new construction flow

## Testing
- pytest tests/unit/data/joint_distributions/test_noisy_distribution_basic.py tests/unit/data/joint_distributions/configs/test_noisy_distribution_config.py tests/unit/data/joint_distributions/test_average_output_variance.py tests/unit/data/iterators/test_noisy_iterator.py

------
https://chatgpt.com/codex/tasks/task_e_68d57a406ad88320aa49b9c2a792dd2b