### PR TITLE
Refactor noisy distribution base sampling

### DIFF
--- a/src/data/providers/noisy_provider.py
+++ b/src/data/providers/noisy_provider.py
@@ -49,5 +49,5 @@ class NoisyProvider(DataProvider):
             X_base = batch[0]
             y_base = batch[1]
             y_noise = batch[2]
-            X_final = self.joint_distribution.base_joint_distribution.forward_X(X_base)
+            X_final = self.joint_distribution.forward_X(X_base)
             yield X_final, y_base + y_noise

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -44,8 +44,16 @@ def benchmark_logger():
             target = describe_target_function(dist.target_function)
             return f"MappedJointDistribution(base={base}, target={target})"
         if dist.config.distribution_type == "NoisyDistribution":
-            base = describe_distribution(dist.base_joint_distribution)
-            noise = describe_distribution(dist.noise_distribution)
+            base = getattr(
+                dist,
+                "base_distribution_description",
+                "UniformHypercube",
+            )
+            noise = getattr(
+                dist,
+                "noise_distribution_description",
+                f"Normal(mean={dist.config.noise_mean}, std={dist.config.noise_std})",
+            )
             return f"NoisyDistribution(base={base}, noise={noise})"
         return dist.__class__.__name__
 


### PR DESCRIPTION
## Summary
- inline the uniform hypercube sampling logic used by `NoisyDistribution`
- expose distribution descriptions for benchmarking utilities
- update the noisy provider to rely on `NoisyDistribution.forward_X`

## Testing
- `pytest tests/unit/data/joint_distributions/test_noisy_distribution_basic.py tests/unit/data/iterators/test_noisy_iterator.py`


------
https://chatgpt.com/codex/tasks/task_e_68d580e03b2083208e16c8a72eac79a6