### PR TITLE
Rename NoisyDistribution to CubeDistribution

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -45,7 +45,7 @@ src/
         to build the provider.  Device placement is inherited from ``dist`` and
         the factory resolves the provider class via :data:`DATA_PROVIDER_REGISTRY`.
   - **`MappedJointDistribution`** – pairs a `Distribution` with a `TargetFunction`; `sample(seed)` draws `X` then computes `y = f(X)`.
-- **`NoisyDistribution`** – mirrors a `MappedJointDistribution` built from a base distribution and target function, then adds Gaussian noise with configurable mean and standard deviation to its targets.
+- **`CubeDistribution`** – mirrors a `MappedJointDistribution` built from a base distribution and target function, then adds Gaussian noise with configurable mean and standard deviation to its targets.
 
 #### Target Functions
 

--- a/scripts/train_mlp/train_mlp.yaml
+++ b/scripts/train_mlp/train_mlp.yaml
@@ -19,7 +19,7 @@ trainer_config:
         mup: true
         weight_decay: 0.0
     joint_distribution_config:
-        distribution_type: NoisyDistribution
+        distribution_type: CubeDistribution
         input_dim: 16
         indices_list:
         - [0]

--- a/src/data/joint_distributions/bootstrap.py
+++ b/src/data/joint_distributions/bootstrap.py
@@ -5,12 +5,12 @@
 from . import gaussian  # noqa: F401
 from . import hypercube  # noqa: F401
 from . import mapped_joint_distribution  # noqa: F401
-from . import noisy_distribution  # noqa: F401
+from . import cube_distribution  # noqa: F401
 from . import staircase  # noqa: F401
 
 # Corresponding config modules
 from .configs import gaussian as gaussian_config  # noqa: F401
 from .configs import hypercube as hypercube_config  # noqa: F401
 from .configs import mapped_joint_distribution as mapped_joint_distribution_config  # noqa: F401
-from .configs import noisy_distribution as noisy_distribution_config  # noqa: F401
+from .configs import cube_distribution as cube_distribution_config  # noqa: F401
 from .configs import staircase as staircase_config  # noqa: F401

--- a/src/data/joint_distributions/configs/cube_distribution.py
+++ b/src/data/joint_distributions/configs/cube_distribution.py
@@ -9,10 +9,10 @@ from .joint_distribution_config_registry import register_joint_distribution_conf
 from src.models.targets.configs.sum_prod import SumProdTargetConfig
 
 
-@register_joint_distribution_config("NoisyDistribution")
+@register_joint_distribution_config("CubeDistribution")
 @dataclass_json
 @dataclass(kw_only=True)
-class NoisyDistributionConfig(JointDistributionConfig):
+class CubeDistributionConfig(JointDistributionConfig):
     input_dim: int
     indices_list: List[List[int]] = field(default_factory=list)
     weights: List[float] = field(default_factory=list)
@@ -57,5 +57,5 @@ class NoisyDistributionConfig(JointDistributionConfig):
             normalize=self.normalize,
         )
 
-        self.distribution_type = "NoisyDistribution"
+        self.distribution_type = "CubeDistribution"
 

--- a/src/data/joint_distributions/cube_distribution.py
+++ b/src/data/joint_distributions/cube_distribution.py
@@ -4,13 +4,13 @@ import torch
 import random
 
 from .joint_distribution import JointDistribution
-from .configs.noisy_distribution import NoisyDistributionConfig
+from .configs.cube_distribution import CubeDistributionConfig
 from .joint_distribution_registry import register_joint_distribution
 from src.models.targets.sum_prod import SumProdTarget
 
-@register_joint_distribution("NoisyDistribution")
-class NoisyDistribution(JointDistribution):
-    def __init__(self, config: NoisyDistributionConfig, device: torch.device) -> None:
+@register_joint_distribution("CubeDistribution")
+class CubeDistribution(JointDistribution):
+    def __init__(self, config: CubeDistributionConfig, device: torch.device) -> None:
         self.base_input_shape = config.input_shape
         self.base_input_size = math.prod(self.base_input_shape)
         self.base_dtype = torch.float32
@@ -48,7 +48,7 @@ class NoisyDistribution(JointDistribution):
             f"{self.output_dim}-dimensional Normal(mean={self.config.noise_mean}, "
             f"std={self.config.noise_std})"
         )
-        return f"NoisyDistribution with {base_str} and {noise_str}"
+        return f"CubeDistribution with {base_str} and {noise_str}"
     
     def get_seeds(self, seed: int) -> Tuple[int, int]:
         splitter = random.Random(seed)
@@ -99,7 +99,7 @@ class NoisyDistribution(JointDistribution):
         return "NoisyProvider"
 
     def forward(self, base_X: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
-        assert False, "NoisyDistribution is not well-specified"
+        assert False, "CubeDistribution is not well-specified"
 
     def forward_X(self, base_X: torch.Tensor) -> torch.Tensor:
         if base_X.shape[1:] == self.base_input_shape:

--- a/src/data/providers/noisy_provider.py
+++ b/src/data/providers/noisy_provider.py
@@ -19,8 +19,8 @@ class NoisyProvider(DataProvider):
     def __post_init__(self) -> None:
         assert (
             self.joint_distribution.config.distribution_type
-            == "NoisyDistribution"
-        ), "NoisyIterator can only be used with NoisyDistribution"
+            == "CubeDistribution"
+        ), "NoisyIterator can only be used with CubeDistribution"
         self.data_loader = self.make_loader()
 
     def make_loader(self) -> DataLoader:

--- a/src/data/providers/seeded_noisy_dataset.py
+++ b/src/data/providers/seeded_noisy_dataset.py
@@ -18,13 +18,13 @@ class SeededNoisyDataset(Dataset):
         seed: int = 0,
     ) -> None:
         assert (
-            distribution.config.distribution_type == "NoisyDistribution"
-        ), "SeededNoisyDataset requires a NoisyDistribution"
+            distribution.config.distribution_type == "CubeDistribution"
+        ), "SeededNoisyDataset requires a CubeDistribution"
         self.distribution = distribution
         self.size = size
         self.seed = seed
 
-        # Cache shape metadata provided directly by ``NoisyDistribution`` so
+        # Cache shape metadata provided directly by ``CubeDistribution`` so
         # that ``__getitem__`` does not need to recompute it for every sample.
         self._base_size = distribution.base_input_size
         self._base_shape = distribution.base_input_shape
@@ -35,7 +35,7 @@ class SeededNoisyDataset(Dataset):
         return self.size
 
     def __getitem__(self, idx: int):  # type: ignore[override]
-        # ``NoisyDistribution.base_sample`` concatenates the flattened base
+        # ``CubeDistribution.base_sample`` concatenates the flattened base
         # features with a noise sample. Draw a single combined sample and then
         # split it back into the two components.
 

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -43,7 +43,7 @@ def benchmark_logger():
             base = describe_distribution(dist.distribution)
             target = describe_target_function(dist.target_function)
             return f"MappedJointDistribution(base={base}, target={target})"
-        if dist.config.distribution_type == "NoisyDistribution":
+        if dist.config.distribution_type == "CubeDistribution":
             base = getattr(
                 dist,
                 "base_distribution_description",
@@ -54,7 +54,7 @@ def benchmark_logger():
                 "noise_distribution_description",
                 f"Normal(mean={dist.config.noise_mean}, std={dist.config.noise_std})",
             )
-            return f"NoisyDistribution(base={base}, noise={noise})"
+            return f"CubeDistribution(base={base}, noise={noise})"
         return dist.__class__.__name__
 
     def log(iterator, distribution, batch_size, dataset_size, epochs, elapsed):

--- a/tests/unit/data/conftest.py
+++ b/tests/unit/data/conftest.py
@@ -17,7 +17,7 @@ from src.training.trainer_config import TrainerConfig
 from src.training.loss.configs.loss import LossConfig
 from tests.helpers.stubs import StubJointDistribution
 import src.data.providers.noisy_provider  # Register NoisyIterator
-from src.data.joint_distributions.configs.noisy_distribution import NoisyDistributionConfig
+from src.data.joint_distributions.configs.cube_distribution import CubeDistributionConfig
 
 
 @pytest.fixture
@@ -212,7 +212,7 @@ def trained_trainer(tmp_path, mlp_config, adam_config) -> Trainer:
 
 @pytest.fixture
 def trained_noisy_trainer(tmp_path, adam_config) -> Trainer:
-    """Return a Trainer using a NoisyDistribution trained for one epoch."""
+    """Return a Trainer using a CubeDistribution trained for one epoch."""
     home = tmp_path / "noisy_trainer_home"
     home.mkdir()
     model_cfg = MLPConfig(
@@ -226,7 +226,7 @@ def trained_noisy_trainer(tmp_path, adam_config) -> Trainer:
     cfg = TrainerConfig(
         model_config=model_cfg,
         optimizer_config=adam_config,
-        joint_distribution_config=NoisyDistributionConfig(
+        joint_distribution_config=CubeDistributionConfig(
             input_dim=2,
             indices_list=[[0]],
             weights=[0.0],

--- a/tests/unit/data/iterators/test_noisy_iterator.py
+++ b/tests/unit/data/iterators/test_noisy_iterator.py
@@ -2,14 +2,14 @@ import pytest
 import torch
 
 from src.data.joint_distributions import create_joint_distribution
-from src.data.joint_distributions.configs.noisy_distribution import NoisyDistributionConfig
+from src.data.joint_distributions.configs.cube_distribution import CubeDistributionConfig
 from src.data.providers.noisy_provider import NoisyProvider
 from src.data.providers import create_data_provider_from_distribution
 from tests.unit.data.conftest import dummy_distribution
 
 
 def _make_distribution():
-    cfg = NoisyDistributionConfig(
+    cfg = CubeDistributionConfig(
         input_dim=2,
         indices_list=[[0]],
         weights=[0.0],
@@ -44,7 +44,7 @@ def test_noisy_iterator_deterministic(tmp_path):
     assert all(torch.equal(a[0], b[0]) and torch.equal(a[1], b[1]) for a, b in zip(first, second))
 
 
-def test_noisy_iterator_requires_noisy_distribution(tmp_path, dummy_distribution):
+def test_noisy_iterator_requires_cube_distribution(tmp_path, dummy_distribution):
     with pytest.raises(AssertionError):
         NoisyProvider(dummy_distribution, tmp_path, seed=0, batch_size=1, dataset_size=1)
 

--- a/tests/unit/data/joint_distributions/configs/test_cube_distribution_config.py
+++ b/tests/unit/data/joint_distributions/configs/test_cube_distribution_config.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from src.data.joint_distributions.configs.noisy_distribution import NoisyDistributionConfig
+from src.data.joint_distributions.configs.cube_distribution import CubeDistributionConfig
 from src.data.joint_distributions.configs.joint_distribution_config_registry import (
     JOINT_DISTRIBUTION_CONFIG_REGISTRY,
     build_joint_distribution_config,
@@ -9,17 +9,17 @@ from src.data.joint_distributions.configs.joint_distribution_config_registry imp
 )
 
 
-def test_noisy_config_registered():
-    assert "NoisyDistribution" in JOINT_DISTRIBUTION_CONFIG_REGISTRY
+def test_cube_config_registered():
+    assert "CubeDistribution" in JOINT_DISTRIBUTION_CONFIG_REGISTRY
     assert (
-        JOINT_DISTRIBUTION_CONFIG_REGISTRY["NoisyDistribution"]
-        is NoisyDistributionConfig
+        JOINT_DISTRIBUTION_CONFIG_REGISTRY["CubeDistribution"]
+        is CubeDistributionConfig
     )
 
 
-def test_build_noisy_config():
+def test_build_cube_config():
     cfg = build_joint_distribution_config(
-        "NoisyDistribution",
+        "CubeDistribution",
         input_dim=2,
         indices_list=[[0]],
         weights=[0.0],
@@ -27,8 +27,8 @@ def test_build_noisy_config():
         noise_mean=1.0,
         noise_std=0.5,
     )
-    assert isinstance(cfg, NoisyDistributionConfig)
-    assert cfg.distribution_type == "NoisyDistribution"
+    assert isinstance(cfg, CubeDistributionConfig)
+    assert cfg.distribution_type == "CubeDistribution"
     assert cfg.input_shape == torch.Size([2])
     assert cfg.output_shape == torch.Size([1])
     assert cfg.noise_mean == pytest.approx(1.0)
@@ -36,8 +36,8 @@ def test_build_noisy_config():
     assert cfg.target_function_config.indices_list == [[0]]
 
 
-def test_noisy_config_json_roundtrip():
-    cfg = NoisyDistributionConfig(
+def test_cube_config_json_roundtrip():
+    cfg = CubeDistributionConfig(
         input_dim=2,
         indices_list=[[0], [1]],
         weights=[1.0, 1.0],
@@ -46,13 +46,13 @@ def test_noisy_config_json_roundtrip():
         noise_std=1.0,
     )
     json_str = cfg.to_json()
-    restored = NoisyDistributionConfig.from_json(json_str)
+    restored = CubeDistributionConfig.from_json(json_str)
     assert restored == cfg
 
 
-def test_noisy_config_from_dict_via_registry():
+def test_cube_config_from_dict_via_registry():
     data = {
-        "distribution_type": "NoisyDistribution",
+        "distribution_type": "CubeDistribution",
         "input_dim": 2,
         "indices_list": [[0], [1]],
         "weights": [1.0, 1.0],
@@ -61,7 +61,7 @@ def test_noisy_config_from_dict_via_registry():
         "noise_std": 0.75,
     }
     cfg = build_joint_distribution_config_from_dict(data)
-    assert isinstance(cfg, NoisyDistributionConfig)
+    assert isinstance(cfg, CubeDistributionConfig)
     assert cfg.input_shape == torch.Size([2])
     assert cfg.output_shape == torch.Size([1])
     assert cfg.noise_mean == pytest.approx(0.25)

--- a/tests/unit/data/joint_distributions/test_average_output_variance.py
+++ b/tests/unit/data/joint_distributions/test_average_output_variance.py
@@ -6,8 +6,8 @@ from src.data.joint_distributions.configs.gaussian import GaussianConfig
 from src.data.joint_distributions.configs.mapped_joint_distribution import (
     MappedJointDistributionConfig,
 )
-from src.data.joint_distributions.configs.noisy_distribution import (
-    NoisyDistributionConfig,
+from src.data.joint_distributions.configs.cube_distribution import (
+    CubeDistributionConfig,
 )
 from src.models.targets.configs.sum_prod import SumProdTargetConfig
 
@@ -36,8 +36,8 @@ def test_mapped_linear_variance_matches_dimension():
     assert var == pytest.approx(3.0, abs=0.2)
 
 
-def test_noisy_distribution_variance_zero():
-    noisy_cfg = NoisyDistributionConfig(
+def test_cube_distribution_variance_zero():
+    cube_cfg = CubeDistributionConfig(
         input_dim=2,
         indices_list=[[0]],
         weights=[0.0],
@@ -45,7 +45,7 @@ def test_noisy_distribution_variance_zero():
         noise_mean=1.0,
         noise_std=0.0,
     )
-    dist = create_joint_distribution(noisy_cfg, torch.device("cpu"))
+    dist = create_joint_distribution(cube_cfg, torch.device("cpu"))
     var = dist.average_output_variance(n_samples=1000, seed=0)
     assert var == pytest.approx(0.0, abs=1e-6)
 

--- a/tests/unit/data/joint_distributions/test_cube_distribution_basic.py
+++ b/tests/unit/data/joint_distributions/test_cube_distribution_basic.py
@@ -3,11 +3,11 @@ import torch
 import torch.nn as nn
 
 from src.data.joint_distributions import create_joint_distribution
-from src.data.joint_distributions.configs.noisy_distribution import NoisyDistributionConfig
+from src.data.joint_distributions.configs.cube_distribution import CubeDistributionConfig
 
 
-def test_noisy_distribution_construct_and_sample():
-    cfg = NoisyDistributionConfig(
+def test_cube_distribution_construct_and_sample():
+    cfg = CubeDistributionConfig(
         input_dim=2,
         indices_list=[[0]],
         weights=[1.0],
@@ -21,7 +21,7 @@ def test_noisy_distribution_construct_and_sample():
     assert y.shape == (3, *dist.output_shape)
 
 
-def test_noisy_distribution_requires_scalar_target(monkeypatch):
+def test_cube_distribution_requires_scalar_target(monkeypatch):
     class MultiTarget(nn.Module):
         def __init__(self, cfg):  # pragma: no cover - validation occurs via exception
             super().__init__()
@@ -31,11 +31,11 @@ def test_noisy_distribution_requires_scalar_target(monkeypatch):
             return torch.zeros(batch, 2, device=x.device, dtype=x.dtype)
 
     monkeypatch.setattr(
-        "src.data.joint_distributions.noisy_distribution.SumProdTarget",
+        "src.data.joint_distributions.cube_distribution.SumProdTarget",
         MultiTarget,
     )
 
-    cfg = NoisyDistributionConfig(
+    cfg = CubeDistributionConfig(
         input_dim=2,
         indices_list=[[0]],
         weights=[1.0],


### PR DESCRIPTION
## Summary
- rename the noisy joint distribution and configuration to CubeDistribution and update registry wiring
- adjust providers, bootstrap imports, documentation, and yaml configuration to reference the new CubeDistribution name
- refresh tests and helper utilities to import the cube distribution classes and updated identifiers

## Testing
- pytest tests/unit/data/joint_distributions tests/unit/data/iterators/test_noisy_iterator.py

------
https://chatgpt.com/codex/tasks/task_e_68d5a9bccb7c8320ae4607fd93dc6519