### PR TITLE
Decouple CubeDistribution from JointDistribution

### DIFF
--- a/tests/unit/test_registry_bootstrap.py
+++ b/tests/unit/test_registry_bootstrap.py
@@ -22,7 +22,7 @@ def test_data_provider_registry_bootstrap():
 def test_joint_distribution_registry_bootstrap():
     import src.data.joint_distributions as dists
     importlib.reload(dists)
-    assert "CubeDistribution" in dists.JOINT_DISTRIBUTION_REGISTRY
+    assert "CubeDistribution" not in dists.JOINT_DISTRIBUTION_REGISTRY
 
 
 def test_model_registry_bootstrap():


### PR DESCRIPTION
## Summary
- remove the JointDistribution base class from CubeDistribution and inline the helper logic it relied on
- stop registering CubeDistribution with the joint distribution registry now that it no longer fits the interface
- update the registry bootstrap test to reflect the new distribution lifecycle

## Testing
- pytest tests/unit/data/joint_distributions/test_cube_distribution_basic.py tests/unit/test_registry_bootstrap.py


------
https://chatgpt.com/codex/tasks/task_e_68d684e44e988320832b2eeefbe6190d