### PR TITLE
Refactor trainer to inline MSE handling

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -156,7 +156,6 @@ from src.models.targets.sum_prod import SumProdTarget
 from src.models.architectures.configs.mlp import MLPConfig
 from src.training.optimizers.configs.adam import AdamConfig
 from src.training.trainer_config import TrainerConfig
-from src.training.loss.configs.loss import LossConfig
 from src.training.trainer import Trainer
 
 cube_cfg = CubeDistributionConfig(
@@ -182,7 +181,6 @@ cfg = TrainerConfig(
     batch_size=8,
     epochs=1,
     home_dir=Path("/tmp/home"),
-    loss_config=LossConfig(name="MSELoss"),
     seed=0,
 )
 

--- a/readme.txt
+++ b/readme.txt
@@ -45,7 +45,6 @@ from src.models.targets.sum_prod import SumProdTarget
 from src.models.architectures.configs.mlp import MLPConfig
 from src.training.optimizers.configs.adam import AdamConfig
 from src.training.trainer_config import TrainerConfig
-from src.training.loss.configs.loss import LossConfig
 from src.training.trainer import Trainer
 
 cube_cfg = CubeDistributionConfig(
@@ -71,7 +70,6 @@ cfg = TrainerConfig(
     batch_size=8,
     epochs=1,
     home_dir=Path("/tmp/home"),
-    loss_config=LossConfig(name="MSELoss"),
     seed=0,
 )
 

--- a/scripts/train_mlp/train_mlp.yaml
+++ b/scripts/train_mlp/train_mlp.yaml
@@ -50,9 +50,6 @@ trainer_config:
         normalize: true
         noise_mean: 0.0
         noise_std: 0.1
-    loss_config:
-        name: MSELoss
-        eval_type: regression
     train_size: 1024
     test_size: 1024
     batch_size: 128

--- a/src/training/trainer_config.py
+++ b/src/training/trainer_config.py
@@ -5,14 +5,12 @@ from dataclasses_json import dataclass_json, config
 from pathlib import Path
 from typing import Optional
 import copy
-import torch
 
 from src.models.architectures.configs.base import ModelConfig
 from src.models.architectures.configs.model_config_registry import build_model_config_from_dict
 from src.data.joint_distributions.configs.cube_distribution import (
     CubeDistributionConfig,
 )
-from src.training.loss.configs.loss import LossConfig
 from src.utils.serialization_utils import encode_path, decode_path
 from src.training.optimizers.configs.optimizer import OptimizerConfig
 from src.training.optimizers.configs.optimizer_config_registry import (
@@ -36,13 +34,6 @@ class TrainerConfig:
         metadata=config(
             encoder=lambda jd: None if jd is None else jd.to_dict(),
             decoder=lambda d: None if d is None else CubeDistributionConfig.from_dict(d),
-        ),
-    )
-    loss_config: Optional[LossConfig] = field(
-        default=None,
-        metadata=config(
-            encoder=lambda l: None if l is None else l.to_dict(),
-            decoder=lambda d: None if d is None else LossConfig.from_dict(d),
         ),
     )
     optimizer_config: Optional[OptimizerConfig] = field(
@@ -77,10 +68,6 @@ class TrainerConfig:
         assert (
             self.cube_distribution_config is not None
         ), "cube_distribution_config must be specified"
-        assert self.loss_config is not None, "loss_config must be specified"
-        assert hasattr(torch.nn, self.loss_config.name), (
-            f"Loss '{self.loss_config.name}' must exist in torch.nn"
-        )
         assert self.train_size is not None, "train_size must be specified"
         assert self.test_size is not None, "test_size must be specified"
         assert self.home_dir is not None, "home_dir must be specified"

--- a/tests/config/test_trainer_config.py
+++ b/tests/config/test_trainer_config.py
@@ -1,5 +1,4 @@
 from src.training.trainer_config import TrainerConfig
-from src.training.loss.configs.loss import LossConfig
 from src.models.architectures.configs.mlp import MLPConfig
 from src.training.optimizers.configs.adam import AdamConfig
 from src.data.joint_distributions.configs.cube_distribution import (
@@ -8,6 +7,8 @@ from src.data.joint_distributions.configs.cube_distribution import (
 
 
 def test_default_optimizer(tmp_path):
+    home_dir = tmp_path / "trainer_home"
+    home_dir.mkdir()
     cfg = TrainerConfig(
         model_config=MLPConfig(
             input_dim=3,
@@ -26,8 +27,7 @@ def test_default_optimizer(tmp_path):
         test_size=5,
         batch_size=2,
         epochs=1,
-        home_dir=tmp_path / "trainer_home",
-        loss_config=LossConfig(name="MSELoss"),
+        home_dir=home_dir,
     )
     assert isinstance(cfg.optimizer_config, AdamConfig)
     assert cfg.optimizer_config.lr == 0.001

--- a/tests/training/test_optimizer_values_dump.py
+++ b/tests/training/test_optimizer_values_dump.py
@@ -3,7 +3,6 @@ import src.models.bootstrap  # noqa: F401
 
 from src.training.trainer import Trainer
 from src.training.trainer_config import TrainerConfig
-from src.training.loss.configs.loss import LossConfig
 from src.models.architectures.configs.mlp import MLPConfig
 from src.training.optimizers.configs.adam import AdamConfig
 from src.data.joint_distributions.configs.cube_distribution import (
@@ -35,7 +34,6 @@ def test_optimizer_values_written(tmp_path):
         batch_size=2,
         epochs=1,
         home_dir=tmp_path,
-        loss_config=LossConfig(name="MSELoss"),
         seed=0,
     )
     trainer = Trainer(cfg)

--- a/tests/training/test_step_trainer.py
+++ b/tests/training/test_step_trainer.py
@@ -2,7 +2,6 @@ import src.models.bootstrap  # noqa: F401
 
 from src.training.trainer import Trainer
 from src.training.trainer_config import TrainerConfig
-from src.training.loss.configs.loss import LossConfig
 from src.models.architectures.configs.mlp import MLPConfig
 from src.training.optimizers.configs.adam import AdamConfig
 from src.data.joint_distributions.configs.cube_distribution import (
@@ -36,7 +35,6 @@ def test_trainer_completes_epoch(tmp_path):
         batch_size=2,
         epochs=1,
         home_dir=tmp_path,
-        loss_config=LossConfig(name="MSELoss"),
         seed=0,
     )
 

--- a/tests/unit/data/conftest.py
+++ b/tests/unit/data/conftest.py
@@ -13,7 +13,6 @@ from src.models.architectures.configs.mlp import MLPConfig
 from src.models.architectures.model_factory import create_model
 from src.training.trainer import Trainer
 from src.training.trainer_config import TrainerConfig
-from src.training.loss.configs.loss import LossConfig
 from src.data.joint_distributions.configs.cube_distribution import CubeDistributionConfig
 
 
@@ -196,7 +195,6 @@ def trained_trainer(tmp_path, mlp_config, adam_config) -> Trainer:
         batch_size=2,
         epochs=1,
         home_dir=home,
-        loss_config=LossConfig(name="MSELoss"),
         seed=0,
     )
     trainer = Trainer(cfg)
@@ -233,7 +231,6 @@ def trained_noisy_trainer(tmp_path, adam_config) -> Trainer:
         batch_size=2,
         epochs=1,
         home_dir=home,
-        loss_config=LossConfig(name="MSELoss"),
         seed=0,
     )
     trainer = Trainer(cfg)

--- a/tests/unit/experiments/test_train_mlp_experiment.py
+++ b/tests/unit/experiments/test_train_mlp_experiment.py
@@ -3,7 +3,6 @@ import src.models.bootstrap  # noqa: F401
 
 from src.training.trainer_config import TrainerConfig
 from src.models.architectures.configs.mlp import MLPConfig
-from src.training.loss.configs.loss import LossConfig
 from src.experiments.configs.train_mlp import TrainMLPExperimentConfig
 from src.experiments.experiments.train_mlp_experiment import TrainMLPExperiment
 from src.utils.seed_manager import SeedManager
@@ -28,12 +27,9 @@ def _make_trainer_config() -> TrainerConfig:
         noise_mean=0.0,
         noise_std=0.0,
     )
-    loss_cfg = LossConfig(name='MSELoss', eval_type='regression')
-
     return TrainerConfig(
         model_config=model_cfg,
         cube_distribution_config=dist_cfg,
-        loss_config=loss_cfg,
         train_size=1,
         test_size=1,
         batch_size=1,

--- a/tests/unit/gpu/test_cross_device_loading.py
+++ b/tests/unit/gpu/test_cross_device_loading.py
@@ -6,7 +6,6 @@ import src.models.bootstrap  # noqa: F401
 from tests.unit.gpu.test_gpu_compatibility import available_gpu, _cube_config
 from src.training.trainer import Trainer
 from src.training.trainer_config import TrainerConfig
-from src.training.loss.configs.loss import LossConfig
 
 
 def _assert_on_cpu(model, optimizer):
@@ -37,7 +36,6 @@ def test_cross_device_loading(tmp_path, mlp_config, adam_config):
         batch_size=2,
         epochs=1,
         home_dir=home,
-        loss_config=LossConfig(name="MSELoss"),
         seed=0,
     )
 

--- a/tests/unit/gpu/test_gpu_compatibility.py
+++ b/tests/unit/gpu/test_gpu_compatibility.py
@@ -10,7 +10,6 @@ from src.data.joint_distributions.configs.cube_distribution import (
 from src.data.providers import create_data_provider_from_distribution
 from src.training.trainer import Trainer
 from src.training.trainer_config import TrainerConfig
-from src.training.loss.configs.loss import LossConfig
 
 
 def available_gpu():
@@ -82,7 +81,6 @@ def test_trainer_runs_on_gpu(tmp_path, mlp_config, adam_config):
         batch_size=2,
         epochs=1,
         home_dir=home,
-        loss_config=LossConfig(name="MSELoss"),
         seed=0,
     )
 

--- a/tests/unit/training/configs/test_trainer.py
+++ b/tests/unit/training/configs/test_trainer.py
@@ -1,6 +1,5 @@
 import pytest
 from src.training.trainer_config import TrainerConfig
-from src.training.loss.configs.loss import LossConfig
 from src.models.architectures.configs.mlp import MLPConfig
 from src.data.joint_distributions.configs.cube_distribution import (
     CubeDistributionConfig,
@@ -9,6 +8,8 @@ import pytest
 
 
 def test_trainer_config_json_roundtrip(tmp_path):
+    home_dir = tmp_path / "trainer_home"
+    home_dir.mkdir()
     cfg = TrainerConfig(
         model_config=MLPConfig(
             input_dim=3,
@@ -29,8 +30,7 @@ def test_trainer_config_json_roundtrip(tmp_path):
         test_size=5,
         batch_size=2,
         epochs=1,
-        home_dir=tmp_path / "trainer_home",
-        loss_config=LossConfig(name="MSELoss"),
+        home_dir=home_dir,
         seed=42,
     )
 
@@ -40,6 +40,8 @@ def test_trainer_config_json_roundtrip(tmp_path):
 
 
 def test_trainer_config_requires_output_shape(tmp_path, mlp_config, adam_config):
+    home_dir = tmp_path / "h"
+    home_dir.mkdir()
     cfg = TrainerConfig(
         model_config=mlp_config,
         cube_distribution_config=CubeDistributionConfig(
@@ -51,8 +53,7 @@ def test_trainer_config_requires_output_shape(tmp_path, mlp_config, adam_config)
         test_size=1,
         batch_size=1,
         epochs=1,
-        home_dir=tmp_path / "h",
-        loss_config=LossConfig(name="MSELoss"),
+        home_dir=home_dir,
     )
     with pytest.raises(AssertionError):
         cfg.ready_for_trainer()

--- a/tests/unit/training/test_l1_penalty.py
+++ b/tests/unit/training/test_l1_penalty.py
@@ -3,7 +3,6 @@ import pytest
 
 from src.training.trainer import Trainer
 from src.training.trainer_config import TrainerConfig
-from src.training.loss.configs.loss import LossConfig
 from src.training.optimizers.configs.adam import AdamConfig
 from src.models.architectures.configs.mlp import MLPConfig
 from src.models.architectures.mlp import MLP
@@ -36,7 +35,6 @@ def _make_trainer(tmp_path, hidden_dims):
         batch_size=2,
         epochs=0,
         home_dir=tmp_path,
-        loss_config=LossConfig(name="MSELoss"),
     )
     trainer = Trainer(cfg)
     model = MLP(cfg.model_config)


### PR DESCRIPTION
## Summary
- inline the trainer's MSE loss computation instead of using loss_config
- simplify TrainerConfig and documentation to remove the loss configuration field
- update tests and fixtures to reflect the built-in MSE loss behaviour

## Testing
- pytest tests/unit/training -k trainer

------
https://chatgpt.com/codex/tasks/task_e_68d6872752b483208e7e0e2bb46ce7a2