### PR TITLE
Stop using forward_X in NoisyProvider iteration

### DIFF
--- a/src/data/joint_distributions/cube_distribution.py
+++ b/src/data/joint_distributions/cube_distribution.py
@@ -73,9 +73,8 @@ class CubeDistribution:
         x = x.to(self.device)
         noise = noise.to(self.device)
 
-        y_clean = self.target_function(x)
         y_noise = noise
-        return x, y_clean + y_noise
+        return x, self.target(x) + y_noise
 
     def base_sample(self, n_samples: int, seed: int) -> Tuple[torch.Tensor, torch.Tensor]:
         base_seed, noise_seed = self.get_seeds(seed)
@@ -90,13 +89,10 @@ class CubeDistribution:
         x = x.to(self.device)
         noise = noise.to(self.device)
 
-        y_clean = self.target_function(x)
+        return x, noise
 
-        # Keep batch dimension (dim 0) and flatten the rest
-        x_flat = x.reshape(n_samples, -1)
-        noise_flat = noise.reshape(n_samples, -1)
-        x_with_noise = torch.cat([x_flat, noise_flat], dim=1)
-        return x_with_noise, y_clean
+    def target(self, x: torch.Tensor) -> torch.Tensor:
+        return self.target_function(x)
     
     def preferred_provider(self) -> str:
         return "NoisyProvider"

--- a/src/data/providers/noisy_provider.py
+++ b/src/data/providers/noisy_provider.py
@@ -7,7 +7,6 @@ from typing import Iterator, Tuple
 import random
 
 from src.data.providers.data_provider import DataProvider
-from src.data.providers.deterministic_dataset import DeterministicDataset
 from src.data.providers.seeded_noisy_dataset import SeededNoisyDataset
 from src.data.providers.provider_registry import register_data_provider
 
@@ -46,8 +45,8 @@ class NoisyProvider(DataProvider):
 
     def __iter__(self) -> Iterator[Tuple[torch.Tensor, torch.Tensor]]:
         for batch in self.data_loader:
-            X_base = batch[0]
-            y_base = batch[1]
-            y_noise = batch[2]
-            X_final = self.joint_distribution.forward_X(X_base)
-            yield X_final, y_base + y_noise
+            X_base, y_noise = batch
+            X_base = X_base.to(self.joint_distribution.device)
+            y_noise = y_noise.to(self.joint_distribution.device)
+            y_clean = self.joint_distribution.target(X_base)
+            yield X_base, y_clean + y_noise

--- a/src/data/providers/seeded_noisy_dataset.py
+++ b/src/data/providers/seeded_noisy_dataset.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
 
-import math
-
-import torch
 from torch.utils.data import Dataset
 
 from src.data.joint_distributions.joint_distribution import JointDistribution
@@ -24,35 +21,15 @@ class SeededNoisyDataset(Dataset):
         self.size = size
         self.seed = seed
 
-        # Cache shape metadata provided directly by ``CubeDistribution`` so
-        # that ``__getitem__`` does not need to recompute it for every sample.
-        self._base_size = distribution.base_input_size
-        self._base_shape = distribution.base_input_shape
-        self._noise_shape = tuple(distribution.noise_shape)
-        self._noise_size = math.prod(self._noise_shape)
-
     def __len__(self) -> int:  # type: ignore[override]
         return self.size
 
     def __getitem__(self, idx: int):  # type: ignore[override]
-        # ``CubeDistribution.base_sample`` concatenates the flattened base
-        # features with a noise sample. Draw a single combined sample and then
-        # split it back into the two components.
-
-        X_with_noise, y_base = self.distribution.base_sample(
-            1, self.seed + int(idx)
-        )
+        X_base, noise = self.distribution.base_sample(1, self.seed + int(idx))
 
         # Remove the batch dimension for easier slicing
-        X_with_noise = X_with_noise.squeeze(0)
-        y_base = y_base.squeeze(0)
+        X_base = X_base.squeeze(0)
+        noise = noise.squeeze(0)
 
-        X_base_flat = X_with_noise[: self._base_size]
-        X_noise_flat = X_with_noise[self._base_size : self._base_size + self._noise_size]
-
-        X_base = X_base_flat.reshape(*self._base_shape)
-        X_noise = X_noise_flat.reshape(*self._noise_shape)
-
-        # Return the noise sample so that the provider can add it to ``y_base``.
-        return X_base, y_base, X_noise
+        return X_base, noise
 


### PR DESCRIPTION
## Summary
- update CubeDistribution to expose its target function separately from sampling and have base_sample return raw inputs with noise
- simplify SeededNoisyDataset to emit hypercube samples with their associated noise using deterministic seeds
- adjust NoisyProvider to compute clean targets on the fly without relying on forward_X while streaming batches

## Testing
- pytest tests/unit/data/iterators/test_noisy_iterator.py

------
https://chatgpt.com/codex/tasks/task_e_68d6942700388320ab6f414929913b37