### PR TITLE
Refactor trainer to require MLP configuration

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -166,7 +166,7 @@ cube_cfg = CubeDistributionConfig(
     noise_std=0.1,
 )
 cfg = TrainerConfig(
-    model_config=MLPConfig(
+    mlp_config=MLPConfig(
         input_dim=cube_cfg.input_dim,
         output_dim=1,
         hidden_dims=[4],

--- a/readme.txt
+++ b/readme.txt
@@ -55,7 +55,7 @@ cube_cfg = CubeDistributionConfig(
     noise_std=0.0,
 )
 cfg = TrainerConfig(
-    model_config=MLPConfig(
+    mlp_config=MLPConfig(
         input_dim=cube_cfg.input_dim,
         output_dim=1,
         hidden_dims=[4],
@@ -76,7 +76,7 @@ cfg = TrainerConfig(
 trainer = Trainer(cfg)
 target = SumProdTarget(cube_cfg.target_function_config)
 # To construct a μP-scaled network instead of the standard variant, set
-# ``cfg.model_config.mup = True`` before creating the model.
+# ``cfg.mlp_config.mup = True`` before creating the model.
 gen = torch.Generator(device=trainer.device)
 dist = CubeDistribution(cube_cfg, trainer.device)
 provider = create_data_provider_from_distribution(

--- a/scripts/train_mlp/train_mlp.yaml
+++ b/scripts/train_mlp/train_mlp.yaml
@@ -1,7 +1,7 @@
 experiment_type: TrainMLP
 trainer_config:
     trainer_type: Trainer
-    model_config:
+    mlp_config:
         model_type: MLP
         input_dim: 16
         output_dim: 1

--- a/src/training/trainer.py
+++ b/src/training/trainer.py
@@ -30,7 +30,6 @@ from src.data.joint_distributions.cube_distribution import CubeDistribution
 from src.data.providers import create_data_provider_from_distribution
 from src.data.providers.data_provider import DataProvider
 from src.models.architectures.model import Model
-from src.models.architectures.model_factory import create_model
 from src.models.architectures.mlp import MLP
 from src.models.architectures.mlp_utils import (
     export_neuron_input_gradients,
@@ -296,7 +295,8 @@ class Trainer:
     def _initialize_model_and_optimizer(self) -> tuple[Model, Optimizer]:
         assert not self.started_training, "Training already started"
         torch.manual_seed(self.model_seed)
-        model = create_model(self.config.model_config)
+        assert self.config.mlp_config is not None
+        model = MLP(self.config.mlp_config)
         model.to(self.device)
 
         # Save an independent copy of the initial model before any training
@@ -331,7 +331,8 @@ class Trainer:
     def _load_model_and_optimizer(self) -> tuple[Model, Optimizer]:
         checkpoint = Checkpoint.from_dir(self.checkpoint_dir)
         torch.manual_seed(self.model_seed)
-        model = create_model(self.config.model_config)
+        assert self.config.mlp_config is not None
+        model = MLP(self.config.mlp_config)
         torch.manual_seed(self.optimizer_seed)
         optimizer = create_optimizer(self.optimizer_config, model)
         checkpoint.load(model=model, optimizer=optimizer.stepper)

--- a/src/training/trainer_config.py
+++ b/src/training/trainer_config.py
@@ -6,8 +6,7 @@ from pathlib import Path
 from typing import Optional
 import copy
 
-from src.models.architectures.configs.base import ModelConfig
-from src.models.architectures.configs.model_config_registry import build_model_config_from_dict
+from src.models.architectures.configs.mlp import MLPConfig
 from src.data.joint_distributions.configs.cube_distribution import (
     CubeDistributionConfig,
 )
@@ -22,11 +21,11 @@ from src.training.optimizers.configs.adam import AdamConfig
 @dataclass_json
 @dataclass(kw_only=True)
 class TrainerConfig:
-    model_config: Optional[ModelConfig] = field(
+    mlp_config: Optional[MLPConfig] = field(
         default=None,
         metadata=config(
             encoder=lambda m: None if m is None else m.to_dict(),
-            decoder=lambda d: None if d is None else build_model_config_from_dict(d),
+            decoder=lambda d: None if d is None else MLPConfig.from_dict(d),
         ),
     )
     cube_distribution_config: Optional[CubeDistributionConfig] = field(
@@ -64,7 +63,7 @@ class TrainerConfig:
         return copy.deepcopy(self)
 
     def ready_for_trainer(self) -> None:
-        assert self.model_config is not None, "model_config must be specified"
+        assert self.mlp_config is not None, "mlp_config must be specified"
         assert (
             self.cube_distribution_config is not None
         ), "cube_distribution_config must be specified"
@@ -73,20 +72,20 @@ class TrainerConfig:
         assert self.home_dir is not None, "home_dir must be specified"
         assert self.weight_decay_l1 >= 0.0, "weight_decay_l1 must be non-negative"
 
-        assert self.model_config.input_shape == self.cube_distribution_config.input_shape, (
+        assert self.mlp_config.input_shape == self.cube_distribution_config.input_shape, (
             f"Model input shape must match distribution input shape. "
-            f"Model: {self.model_config.input_shape}, "
+            f"Model: {self.mlp_config.input_shape}, "
             f"Distribution: {self.cube_distribution_config.input_shape}"
         )
         assert (
-            self.model_config.output_shape is not None
+            self.mlp_config.output_shape is not None
         ), "Model output shape must not be None"
         assert (
             self.cube_distribution_config.output_shape is not None
         ), "Cube distribution output shape must not be None"
-        assert self.model_config.output_shape == self.cube_distribution_config.output_shape, (
+        assert self.mlp_config.output_shape == self.cube_distribution_config.output_shape, (
             f"Model output shape must match distribution output shape. "
-            f"Model: {self.model_config.output_shape}, "
+            f"Model: {self.mlp_config.output_shape}, "
             f"Distribution: {self.cube_distribution_config.output_shape}"
         )
         assert self.home_dir.exists(), f"Home directory {self.home_dir} does not exist"

--- a/tests/config/test_trainer_config.py
+++ b/tests/config/test_trainer_config.py
@@ -10,7 +10,7 @@ def test_default_optimizer(tmp_path):
     home_dir = tmp_path / "trainer_home"
     home_dir.mkdir()
     cfg = TrainerConfig(
-        model_config=MLPConfig(
+        mlp_config=MLPConfig(
             input_dim=3,
             output_dim=1,
             hidden_dims=[4, 2],

--- a/tests/training/test_optimizer_values_dump.py
+++ b/tests/training/test_optimizer_values_dump.py
@@ -12,7 +12,7 @@ from src.data.joint_distributions.configs.cube_distribution import (
 
 def test_optimizer_values_written(tmp_path):
     cfg = TrainerConfig(
-        model_config=MLPConfig(
+        mlp_config=MLPConfig(
             input_dim=1,
             output_dim=1,
             hidden_dims=[],

--- a/tests/training/test_step_trainer.py
+++ b/tests/training/test_step_trainer.py
@@ -13,7 +13,7 @@ def test_trainer_completes_epoch(tmp_path):
     """Ensure the :class:`Trainer` can run a minimal training loop."""
 
     cfg = TrainerConfig(
-        model_config=MLPConfig(
+        mlp_config=MLPConfig(
             input_dim=1,
             output_dim=1,
             hidden_dims=[],

--- a/tests/unit/data/conftest.py
+++ b/tests/unit/data/conftest.py
@@ -181,7 +181,7 @@ def trained_trainer(tmp_path, mlp_config, adam_config) -> Trainer:
     home = tmp_path / "trainer_home"
     home.mkdir()
     cfg = TrainerConfig(
-        model_config=mlp_config,
+        mlp_config=mlp_config,
         optimizer_config=adam_config,
         cube_distribution_config=CubeDistributionConfig(
             input_dim=mlp_config.input_dim,
@@ -216,7 +216,7 @@ def trained_noisy_trainer(tmp_path, adam_config) -> Trainer:
         end_activation=False,
     )
     cfg = TrainerConfig(
-        model_config=model_cfg,
+        mlp_config=model_cfg,
         optimizer_config=adam_config,
         cube_distribution_config=CubeDistributionConfig(
             input_dim=2,

--- a/tests/unit/experiments/test_train_mlp_experiment.py
+++ b/tests/unit/experiments/test_train_mlp_experiment.py
@@ -28,7 +28,7 @@ def _make_trainer_config() -> TrainerConfig:
         noise_std=0.0,
     )
     return TrainerConfig(
-        model_config=model_cfg,
+        mlp_config=model_cfg,
         cube_distribution_config=dist_cfg,
         train_size=1,
         test_size=1,

--- a/tests/unit/gpu/test_cross_device_loading.py
+++ b/tests/unit/gpu/test_cross_device_loading.py
@@ -28,7 +28,7 @@ def test_cross_device_loading(tmp_path, mlp_config, adam_config):
     home.mkdir()
 
     cfg = TrainerConfig(
-        model_config=mlp_config,
+        mlp_config=mlp_config,
         optimizer_config=adam_config,
         cube_distribution_config=_cube_config(mlp_config.input_dim),
         train_size=4,

--- a/tests/unit/gpu/test_gpu_compatibility.py
+++ b/tests/unit/gpu/test_gpu_compatibility.py
@@ -73,7 +73,7 @@ def test_trainer_runs_on_gpu(tmp_path, mlp_config, adam_config):
     home.mkdir()
 
     cfg = TrainerConfig(
-        model_config=mlp_config,
+        mlp_config=mlp_config,
         optimizer_config=adam_config,
         cube_distribution_config=_cube_config(mlp_config.input_dim),
         train_size=4,

--- a/tests/unit/training/configs/test_trainer.py
+++ b/tests/unit/training/configs/test_trainer.py
@@ -11,7 +11,7 @@ def test_trainer_config_json_roundtrip(tmp_path):
     home_dir = tmp_path / "trainer_home"
     home_dir.mkdir()
     cfg = TrainerConfig(
-        model_config=MLPConfig(
+        mlp_config=MLPConfig(
             input_dim=3,
             output_dim=1,
             hidden_dims=[4, 2],
@@ -43,7 +43,7 @@ def test_trainer_config_requires_output_shape(tmp_path, mlp_config, adam_config)
     home_dir = tmp_path / "h"
     home_dir.mkdir()
     cfg = TrainerConfig(
-        model_config=mlp_config,
+        mlp_config=mlp_config,
         cube_distribution_config=CubeDistributionConfig(
             input_dim=mlp_config.input_dim + 1,
             indices_list=[[0]],

--- a/tests/unit/training/test_l1_penalty.py
+++ b/tests/unit/training/test_l1_penalty.py
@@ -13,7 +13,7 @@ from src.data.joint_distributions.configs.cube_distribution import (
 
 def _make_trainer(tmp_path, hidden_dims):
     cfg = TrainerConfig(
-        model_config=MLPConfig(
+        mlp_config=MLPConfig(
             input_dim=1,
             output_dim=1,
             hidden_dims=hidden_dims,
@@ -37,7 +37,8 @@ def _make_trainer(tmp_path, hidden_dims):
         home_dir=tmp_path,
     )
     trainer = Trainer(cfg)
-    model = MLP(cfg.model_config)
+    assert cfg.mlp_config is not None
+    model = MLP(cfg.mlp_config)
     return trainer, model
 
 

--- a/tests/unit/training/test_trainer_evaluator.py
+++ b/tests/unit/training/test_trainer_evaluator.py
@@ -13,7 +13,7 @@ from src.data.joint_distributions.configs.cube_distribution import (
 
 def test_trainer_reports_mse_loss(tmp_path):
     cfg = TrainerConfig(
-        model_config=MLPConfig(
+        mlp_config=MLPConfig(
             input_dim=1,
             output_dim=1,
             hidden_dims=[],


### PR DESCRIPTION
## Summary
- update TrainerConfig to require an MLPConfig and validate against the distribution shapes
- instantiate trainers' models by constructing MLPs directly and update docs/tests/configs accordingly

## Testing
- pytest tests/unit/training -q

------
https://chatgpt.com/codex/tasks/task_e_68d698755c0883209023150864fac090