### PR TITLE
Remove dataset directory requirement from data providers

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -33,7 +33,7 @@ src/
   configurable Gaussian noise to the targets. The accompanying
   :class:`~src.data.joint_distributions.configs.cube_distribution.CubeDistributionConfig`
   dataclass stores the parameters required to instantiate the distribution.
-- Use ``create_data_provider_from_distribution(dist, dataset_dir, batch_size, dataset_size, seed)``
+- Use ``create_data_provider_from_distribution(dist, batch_size, dataset_size, seed)``
   to build the provider associated with the distribution. Device placement is
   inherited from ``dist`` and the factory resolves the provider class via
   :data:`DATA_PROVIDER_REGISTRY`.
@@ -45,9 +45,8 @@ src/
 #### Data Providers
 
  - **`DataIterator`** – dataclass interface for creating datasets and loaders.
-   Stores ``joint_distribution``, ``dataset_dir``, ``seed``, ``dataset_size``
-   and ``batch_size`` for use by subclasses when constructing ``DataLoader``
-   instances.
+   Stores ``joint_distribution``, ``seed``, ``dataset_size`` and ``batch_size``
+   for use by subclasses when constructing ``DataLoader`` instances.
   - **`TensorDataProvider`** – streams samples using ``DeterministicDataset``.
   - `make_loader()` – instantiate a ``DeterministicDataset`` of that size and return a `DataLoader`.
  - **`DeterministicDataset`** – dataset that draws samples deterministically from a `CubeDistribution`.

--- a/readme.txt
+++ b/readme.txt
@@ -81,7 +81,6 @@ gen = torch.Generator(device=trainer.device)
 dist = CubeDistribution(cube_cfg, trainer.device)
 provider = create_data_provider_from_distribution(
     dist,
-    Path("/tmp"),
     batch_size=32,
     dataset_size=100,
     seed=0,

--- a/src/data/providers/data_provider.py
+++ b/src/data/providers/data_provider.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 from abc import ABC, abstractmethod
-from pathlib import Path
 from dataclasses import dataclass
 from typing import Iterator, Tuple
 
@@ -14,7 +13,6 @@ class DataProvider(ABC):
     """Abstract interface for dataset generation and ``DataLoader`` creation."""
 
     joint_distribution: CubeDistribution
-    dataset_dir: Path
     seed: int
     dataset_size: int
     batch_size: int

--- a/src/data/providers/data_provider_factory.py
+++ b/src/data/providers/data_provider_factory.py
@@ -5,7 +5,6 @@ from .provider_registry import DATA_PROVIDER_REGISTRY
 
 def create_data_provider_from_distribution(
     dist,
-    dataset_dir,
     batch_size,
     dataset_size,
     seed,
@@ -17,7 +16,6 @@ def create_data_provider_from_distribution(
     provider_cls = DATA_PROVIDER_REGISTRY[provider_type]
     return provider_cls(
         dist,
-        dataset_dir,
         seed,
         batch_size=batch_size,
         dataset_size=dataset_size,

--- a/src/experiments/utilities/neuron_comparator.py
+++ b/src/experiments/utilities/neuron_comparator.py
@@ -60,10 +60,8 @@ class NeuronComparator:
         seed = random.randint(0, 2**32 - 1)
         batch_size = student_trainer.config.batch_size or 1024
         dataset_size = student_trainer.config.test_size
-        data_dir = student_trainer.datasets_dir / "comparator"
         self.test_loader = create_data_provider_from_distribution(
             student_trainer.joint_distribution,
-            data_dir,
             batch_size,
             dataset_size,
             seed,

--- a/src/training/trainer.py
+++ b/src/training/trainer.py
@@ -264,7 +264,6 @@ class Trainer:
         batch_size = self.config.batch_size or 1024
         iterator = create_data_provider_from_distribution(
             self.joint_distribution,
-            self.datasets_dir / split,
             batch_size,
             size,
             seed=seed,
@@ -285,7 +284,6 @@ class Trainer:
         batch_size = self.config.batch_size or 1024
         iterator = create_data_provider_from_distribution(
             self.joint_distribution,
-            self.datasets_dir / f"fresh_{seed}",
             batch_size,
             size,
             seed=seed,

--- a/tests/unit/data/iterators/test_data_iterator.py
+++ b/tests/unit/data/iterators/test_data_iterator.py
@@ -3,12 +3,11 @@ import torch
 from src.data.providers.tensor_data_provider import TensorDataProvider
 
 
-def test_make_loader_returns_expected_batches(tmp_path, constant_cube_distribution):
+def test_make_loader_returns_expected_batches(constant_cube_distribution):
     dist = constant_cube_distribution
     seed = 0
     iterator = TensorDataProvider(
         dist,
-        tmp_path,
         seed,
         dataset_size=4,
         batch_size=2,
@@ -28,14 +27,14 @@ def test_make_loader_returns_expected_batches(tmp_path, constant_cube_distributi
     assert torch.allclose(y_all, torch.full((4, 1), 5.0))
 
 
-def test_tensor_iterator_deterministic_across_calls(tmp_path, constant_cube_distribution):
+def test_tensor_iterator_deterministic_across_calls(constant_cube_distribution):
     dist = constant_cube_distribution
 
     seed = 0
-    iterator1 = TensorDataProvider(dist, tmp_path, seed, batch_size=2, dataset_size=4)
+    iterator1 = TensorDataProvider(dist, seed, batch_size=2, dataset_size=4)
     first = list(iterator1.data_loader)
 
-    iterator2 = TensorDataProvider(dist, tmp_path, seed, batch_size=2, dataset_size=4)
+    iterator2 = TensorDataProvider(dist, seed, batch_size=2, dataset_size=4)
     second = list(iterator2.data_loader)
 
     assert all(torch.equal(a[0], b[0]) and torch.equal(a[1], b[1]) for a, b in zip(first, second))

--- a/tests/unit/data/iterators/test_noisy_iterator.py
+++ b/tests/unit/data/iterators/test_noisy_iterator.py
@@ -19,9 +19,9 @@ def _make_distribution():
     return CubeDistribution(cfg, torch.device("cpu"))
 
 
-def test_noisy_iterator_batches_apply_noise(tmp_path):
+def test_noisy_iterator_batches_apply_noise():
     dist = _make_distribution()
-    iterator = NoisyProvider(dist, tmp_path, seed=0, dataset_size=4, batch_size=2)
+    iterator = NoisyProvider(dist, seed=0, dataset_size=4, batch_size=2)
 
     batches = list(iterator)
 
@@ -32,29 +32,28 @@ def test_noisy_iterator_batches_apply_noise(tmp_path):
         assert torch.allclose(y, torch.full((2, 1), 1.0))
 
 
-def test_noisy_iterator_deterministic(tmp_path):
+def test_noisy_iterator_deterministic():
     dist = _make_distribution()
 
-    iterator1 = NoisyProvider(dist, tmp_path, seed=42, batch_size=2, dataset_size=4)
+    iterator1 = NoisyProvider(dist, seed=42, batch_size=2, dataset_size=4)
     first = list(iterator1)
-    iterator2 = NoisyProvider(dist, tmp_path, seed=42, batch_size=2, dataset_size=4)
+    iterator2 = NoisyProvider(dist, seed=42, batch_size=2, dataset_size=4)
     second = list(iterator2)
 
     assert all(torch.equal(a[0], b[0]) and torch.equal(a[1], b[1]) for a, b in zip(first, second))
 
 
-def test_noisy_iterator_requires_cube_distribution(tmp_path):
+def test_noisy_iterator_requires_cube_distribution():
     dist = _make_distribution()
     dist.config.distribution_type = "NotCubeDistribution"
     with pytest.raises(AssertionError):
-        NoisyProvider(dist, tmp_path, seed=0, batch_size=1, dataset_size=1)
+        NoisyProvider(dist, seed=0, batch_size=1, dataset_size=1)
 
 
-def test_preferred_provider(tmp_path):
+def test_preferred_provider():
     dist = _make_distribution()
     provider = create_data_provider_from_distribution(
         dist,
-        tmp_path,
         batch_size=2,
         dataset_size=4,
         seed=0,

--- a/tests/unit/data/iterators/test_preferred_iterator.py
+++ b/tests/unit/data/iterators/test_preferred_iterator.py
@@ -2,13 +2,11 @@ from src.data.providers import create_data_provider_from_distribution
 from src.data.providers.noisy_provider import NoisyProvider
 
 
-def test_create_data_provider_from_distribution_prefers_noisy(tmp_path, constant_cube_distribution):
+def test_create_data_provider_from_distribution_prefers_noisy(constant_cube_distribution):
     provider = create_data_provider_from_distribution(
         constant_cube_distribution,
-        tmp_path,
         batch_size=2,
         dataset_size=10,
         seed=0,
     )
     assert isinstance(provider, NoisyProvider)
-    assert provider.dataset_dir == tmp_path

--- a/tests/unit/gpu/test_gpu_compatibility.py
+++ b/tests/unit/gpu/test_gpu_compatibility.py
@@ -45,7 +45,7 @@ def test_cube_sample_device():
 
 
 @pytest.mark.gpu
-def test_noisy_provider_yields_on_device(tmp_path):
+def test_noisy_provider_yields_on_device():
     device = available_gpu()
     if device is None:
         pytest.skip("GPU not available")
@@ -53,7 +53,6 @@ def test_noisy_provider_yields_on_device(tmp_path):
     dist = CubeDistribution(_cube_config(3), device)
     provider = create_data_provider_from_distribution(
         dist,
-        tmp_path,
         batch_size=2,
         dataset_size=4,
         seed=0,

--- a/tests/unit/models/architectures/test_mlp.py
+++ b/tests/unit/models/architectures/test_mlp.py
@@ -228,7 +228,6 @@ def test_export_neuron_input_gradients_layer_numbering(tmp_path):
     class DummyProvider(DataProvider):
         def __init__(self, X, y):
             self.joint_distribution = None  # type: ignore[assignment]
-            self.dataset_dir = tmp_path
             self.seed = 0
             self.dataset_size = X.size(0)
             self.batch_size = X.size(0)


### PR DESCRIPTION
## Summary
- remove the dataset directory parameter from the `DataProvider` dataclass and factory
- update trainers, utilities, docs, and tests to use the simplified constructor

## Testing
- pytest tests/unit/data/iterators -q

------
https://chatgpt.com/codex/tasks/task_e_68d69d0aa9b48320b6ecf6513fb0b445