### PR TITLE
Refactor NoisyProvider to standalone class

### DIFF
--- a/src/data/providers/noisy_provider.py
+++ b/src/data/providers/noisy_provider.py
@@ -6,14 +6,18 @@ from dataclasses import dataclass
 from typing import Iterator, Tuple
 import random
 
-from src.data.providers.data_provider import DataProvider
+from src.data.joint_distributions.cube_distribution import CubeDistribution
 from src.data.providers.seeded_noisy_dataset import SeededNoisyDataset
 from src.data.providers.provider_registry import register_data_provider
 
 
 @register_data_provider("NoisyProvider")
 @dataclass
-class NoisyProvider(DataProvider):
+class NoisyProvider:
+    joint_distribution: CubeDistribution
+    seed: int
+    dataset_size: int
+    batch_size: int
 
     def __post_init__(self) -> None:
         assert (
@@ -42,6 +46,9 @@ class NoisyProvider(DataProvider):
             shuffle=True,
             generator=g,
         )
+
+    def __len__(self) -> int:
+        return self.dataset_size
 
     def __iter__(self) -> Iterator[Tuple[torch.Tensor, torch.Tensor]]:
         for batch in self.data_loader:

--- a/src/data/providers/provider_registry.py
+++ b/src/data/providers/provider_registry.py
@@ -1,15 +1,12 @@
 from __future__ import annotations
 
-from .data_provider import DataProvider
-
-
-DATA_PROVIDER_REGISTRY: dict[str, type[DataProvider]] = {}
+DATA_PROVIDER_REGISTRY: dict[str, type] = {}
 
 
 def register_data_provider(provider_type: str):
-    """Class decorator to register a :class:`DataIterator` subclass."""
+    """Class decorator to register a data provider implementation."""
 
-    def decorator(cls: type[DataProvider]):
+    def decorator(cls: type):
         DATA_PROVIDER_REGISTRY[provider_type] = cls
         return cls
 


### PR DESCRIPTION
## Summary
- refactor `NoisyProvider` into a standalone dataclass that defines the fields and length previously inherited from `DataProvider`
- relax the data provider registry typing so non-`DataProvider` implementations can register successfully

## Testing
- `pytest tests/unit/data/iterators/test_noisy_iterator.py`

------
https://chatgpt.com/codex/tasks/task_e_68d6e85ac14883209abbcc7e61541ddc