### PR TITLE
Ensure pruned MLP visualization uses true forward activations

### DIFF
--- a/src/models/pruned_mlp.py
+++ b/src/models/pruned_mlp.py
@@ -217,36 +217,11 @@ def visualize_pruned_mlp(
     if not linear_layers:
         return
 
-    def _effective_readout_scale(layer: torch.nn.Module) -> float:
-        """Return the scale factor that maps μP readout weights to real outputs."""
-
-        width_mult_fn = getattr(layer, "width_mult", None)
-        if callable(width_mult_fn):
-            width_mult = float(width_mult_fn())
-            if width_mult != 0.0:
-                output_mult = getattr(layer, "output_mult", 1.0)
-                if isinstance(output_mult, torch.Tensor):
-                    output_mult = float(output_mult.detach().cpu())
-                else:
-                    output_mult = float(output_mult)
-                return output_mult / width_mult
-        return 1.0
-
     weight_tensors: List[torch.Tensor] = []
-    bias_tensors: List[torch.Tensor | None] = []
-
     for idx, layer in enumerate(linear_layers):
         weight = layer.weight.detach().cpu().clone()
 
-        if idx == len(linear_layers) - 1:
-            scale = _effective_readout_scale(layer)
-            if scale != 1.0:
-                weight.mul_(scale)
-
-        bias = layer.bias.detach().cpu().clone() if layer.bias is not None else None
-
         weight_tensors.append(weight)
-        bias_tensors.append(bias)
 
     input_dim = pruned_mlp.config.input_dim
     dtype = weight_tensors[0].dtype
@@ -290,16 +265,19 @@ def visualize_pruned_mlp(
         if inputs.dim() != 2:
             raise ValueError("Expected inputs to be a 1D or 2D tensor")
 
-        prev = inputs.to(dtype=dtype)
+        layer_device = linear_layers[0].weight.device
+        layer_dtype = linear_layers[0].weight.dtype
+
+        prev = inputs.to(device=layer_device, dtype=layer_dtype)
         activations: List[torch.Tensor] = []
-        for layer_idx, (weight, bias) in enumerate(zip(weight_tensors, bias_tensors), start=1):
-            pre_act = F.linear(prev, weight, bias)
-            if layer_idx == len(weight_tensors):
-                activations.append(pre_act)
+        for layer_idx, layer in enumerate(linear_layers, start=1):
+            pre_act = layer(prev)
+            if layer_idx == len(linear_layers):
+                activations.append(pre_act.detach().cpu())
                 prev = pre_act
             else:
                 post_act = F.relu(pre_act)
-                activations.append(post_act)
+                activations.append(post_act.detach().cpu())
                 prev = post_act
         return [tensor.squeeze(0) for tensor in activations]
 

--- a/tests/unit/models/test_pruned_mlp.py
+++ b/tests/unit/models/test_pruned_mlp.py
@@ -19,7 +19,7 @@ def _load_activation_rows(csv_path: Path) -> list[dict[str, float]]:
     return rows
 
 
-def test_visualize_pruned_mlp_emits_scaled_readout(tmp_path):
+def test_visualize_pruned_mlp_matches_model_output(tmp_path):
     config = MLPConfig(input_dim=2, hidden_dims=[3])
     model = MLP(config)
 
@@ -27,7 +27,7 @@ def test_visualize_pruned_mlp_emits_scaled_readout(tmp_path):
         for layer in model.linear_layers:
             layer.weight.fill_(0.25)
             layer.bias.fill_(0.1)
-        # Introduce a non-trivial μP scaling so the readout needs adjustment.
+        # Introduce a non-trivial μP scaling to exercise μP-aware readout behaviour.
         model.linear_layers[-1].output_mult = torch.tensor(0.5)
 
     pruned_model, active_inputs = prune(model)
@@ -36,6 +36,55 @@ def test_visualize_pruned_mlp_emits_scaled_readout(tmp_path):
     visualize_pruned_mlp(pruned_model, active_inputs, output_dir)
 
     final_layer_dir = output_dir / "layer_02"
+    csv_files = sorted(final_layer_dir.glob("*_activations.csv"))
+    assert csv_files, "expected activation CSV files for the readout layer"
+
+    dtype = pruned_model.linear_layers[0].weight.dtype
+
+    for csv_path in csv_files:
+        rows = _load_activation_rows(csv_path)
+        assert rows, "activation CSV should contain rows"
+
+        for row in rows:
+            activation = row.pop("activation")
+            input_vector = torch.zeros(pruned_model.config.input_dim, dtype=dtype)
+            for index_str, value in row.items():
+                input_vector[int(index_str)] = value
+
+            with torch.no_grad():
+                expected = pruned_model(input_vector.unsqueeze(0)).squeeze(0).squeeze(-1)
+
+            assert torch.isclose(torch.tensor(activation, dtype=dtype), expected, atol=1e-6)
+
+
+def test_visualize_pruned_mlp_random_pruned_matches_readout(tmp_path):
+    torch.manual_seed(0)
+
+    config = MLPConfig(input_dim=4, hidden_dims=[6, 5])
+    model = MLP(config)
+
+    rng = torch.Generator().manual_seed(42)
+
+    with torch.no_grad():
+        for layer in model.linear_layers:
+            layer.weight.normal_()
+            layer.bias.normal_()
+
+            sparsity_mask = torch.rand(layer.weight.shape, generator=rng) < 0.4
+            layer.weight.mul_(sparsity_mask.float())
+
+            if layer.bias is not None:
+                bias_mask = torch.rand(layer.bias.shape, generator=rng) < 0.5
+                layer.bias.mul_(bias_mask.float())
+
+    pruned_model, active_inputs = prune(model)
+
+    output_dir = tmp_path / "viz"
+    visualize_pruned_mlp(pruned_model, active_inputs, output_dir)
+
+    final_layer_idx = len(pruned_model.linear_layers)
+    final_layer_dir = output_dir / f"layer_{final_layer_idx:02d}"
+
     csv_files = sorted(final_layer_dir.glob("*_activations.csv"))
     assert csv_files, "expected activation CSV files for the readout layer"
 


### PR DESCRIPTION
## Summary
- run pruned network visualization through the model modules so recorded activations match the live forward pass
- cover μP scaling and a randomly sparsified network with regression tests to ensure the recorded readout activations agree with model outputs

## Testing
- pytest tests/unit/models/test_pruned_mlp.py

------
https://chatgpt.com/codex/tasks/task_e_690c521e8b4c8320a7fcb65eeacef28b